### PR TITLE
Keep operators in order

### DIFF
--- a/pystiche/nst/image_optimizer/image_optimizer.py
+++ b/pystiche/nst/image_optimizer/image_optimizer.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod
 from typing import Any, Optional, Union, Callable, Iterator, Iterable, Sequence
+from collections import OrderedDict
 import itertools
 from math import floor
 import torch
@@ -29,7 +30,7 @@ class ImageOptimizer(pystiche.object):
         self, *operators: Operator, optimizer_getter: Optional[Callable] = None
     ) -> None:
         super().__init__()
-        self._operators = pystiche.set(operators)
+        self._operators = pystiche.tuple(OrderedDict.fromkeys(operators))
 
         encoders = [operator.encoder for operator in self.operators(Encoding)]
         self._encoders = pystiche.set(encoders)


### PR DESCRIPTION
This replaces `pystiche.set` with a combination of `pystiche.tuple` and `OrderedDict`. With it the operators are kept in the order while maintaining uniqueness. Since no operators are added at runtime, no further changes have to be made.