### PR TITLE
Changed multi_encoder_error to warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python: "3.6"
+
+matrix:
+  include:
+    - name: "Formatting"
+      before_install: pip install black
+      install: skip
+      script: black --check .
+    - name: "Tests"
+      before_install: pip install pytest
+      install: pip install .
+      script: pytest test

--- a/pystiche/nst/image_optimizer/image_optimizer.py
+++ b/pystiche/nst/image_optimizer/image_optimizer.py
@@ -164,9 +164,11 @@ class PreprocessingImageOptimizer(ImageOptimizer):
     ) -> None:
         super().__init__(*args, **kwargs)
         if multi_encoder_warning and len(self._encoders) > 1:
-            msg = ("Multiple encoders detected. Are you sure that you want to use "
-                   "multiple encoders with the same preprocessing? To suppress this "
-                   "warning, set multi_encoder_warning=False.")
+            msg = (
+                "Multiple encoders detected. Are you sure that you want to use "
+                "multiple encoders with the same preprocessing? To suppress this "
+                "warning, set multi_encoder_warning=False."
+            )
             warnings.warn(msg, RuntimeWarning)
 
     @abstractmethod

--- a/pystiche/nst/image_optimizer/image_optimizer.py
+++ b/pystiche/nst/image_optimizer/image_optimizer.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod
 from typing import Any, Optional, Union, Callable, Iterator, Iterable, Sequence
+import warnings
 import itertools
 from math import floor
 import torch
@@ -159,12 +160,14 @@ class ImageOptimizer(pystiche.object):
 
 class PreprocessingImageOptimizer(ImageOptimizer):
     def __init__(
-        self, *args: Any, multi_encoder_error: bool = True, **kwargs: Any
+        self, *args: Any, multi_encoder_warning: bool = True, **kwargs: Any
     ) -> None:
         super().__init__(*args, **kwargs)
-        if multi_encoder_error and len(self._encoders) > 1:
-            # TODO: error message
-            raise RuntimeError
+        if multi_encoder_warning and len(self._encoders) > 1:
+            msg = ("Multiple encoders detected. Are you sure that you want to use "
+                   "multiple encoders with the same preprocessing? To suppress this "
+                   "warning, set multi_encoder_warning=False.")
+            warnings.warn(msg, RuntimeWarning)
 
     @abstractmethod
     def preprocess(self, image: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
While it is unusual to have multiple distinct encoders with the different preprocessing, it is certainly not impossible. Thus, this changes the the behaviour from `RuntimeError` to `RuntimeWarning`. 