### PR TITLE
Multi aspect ratio resize in pyramid

### DIFF
--- a/pystiche/nst/image_optimizer/pyramid.py
+++ b/pystiche/nst/image_optimizer/pyramid.py
@@ -226,7 +226,7 @@ class ImageOptimizerOctavePyramid(ImageOptimizerPyramid):
         level_steps: Union[Sequence[int], int],
         num_levels: Optional[int] = None,
         min_edge_size: int = 64,
-        edges: str = "short",
+        edges: Union[Sequence[str], str] = "short",
         **kwargs,
     ):
         if num_levels is None:

--- a/pystiche/nst/image_optimizer/pyramid.py
+++ b/pystiche/nst/image_optimizer/pyramid.py
@@ -1,27 +1,10 @@
-import warnings
-from typing import Union, Optional, Sequence, Tuple, Dict, Callable
-from itertools import repeat
+from typing import Union, Optional, Sequence, Dict, Callable
 import numpy as np
 import torch
 import pystiche
 from pystiche.misc import zip_equal, verify_str_arg
-from pystiche.image import (
-    is_image_size,
-    is_edge_size,
-    calculate_aspect_ratio,
-    image_to_edge_size,
-    extract_image_size,
-    extract_aspect_ratio,
-    edge_to_image_size,
-)
-from pystiche.image.transforms import (
-    Transform,
-    ResizeTransform,
-    Resize,
-    FixedAspectRatioResize,
-    GrayscaleToBinary,
-)
-from pystiche.image.transforms.functional import resize
+from pystiche.image import extract_image_size, extract_aspect_ratio
+from pystiche.image.transforms import FixedAspectRatioResize, GrayscaleToBinary
 from ..operators import Operator, Comparison, Guidance, ComparisonGuidance
 from .image_optimizer import ImageOptimizer
 

--- a/pystiche/nst/image_optimizer/pyramid.py
+++ b/pystiche/nst/image_optimizer/pyramid.py
@@ -1,15 +1,18 @@
 import warnings
 from typing import Union, Optional, Sequence, Tuple, Dict, Callable
+from itertools import repeat
 import numpy as np
 import torch
 import pystiche
-from pystiche.misc import zip_equal
+from pystiche.misc import zip_equal, verify_str_arg
 from pystiche.image import (
     is_image_size,
     is_edge_size,
     calculate_aspect_ratio,
     image_to_edge_size,
     extract_image_size,
+    extract_aspect_ratio,
+    edge_to_image_size,
 )
 from pystiche.image.transforms import (
     Transform,
@@ -18,6 +21,7 @@ from pystiche.image.transforms import (
     FixedAspectRatioResize,
     GrayscaleToBinary,
 )
+from pystiche.image.transforms.functional import resize
 from ..operators import Operator, Comparison, Guidance, ComparisonGuidance
 from .image_optimizer import ImageOptimizer
 
@@ -28,30 +32,51 @@ class PyramidLevel(pystiche.object):
     def __init__(
         self,
         num: int,
+        edge_size: int,
         num_steps: int,
-        transform: Callable,
-        guide_transform: Optional[Callable] = None,
+        edge: str,
+        binarizer: Optional[Callable] = None,
+        interpolation_mode: str = "bilinear",
     ) -> None:
         super().__init__()
         self.num: int = num
+        self.edge_size = edge_size
         self.num_steps: int = num_steps
+        self.edge = verify_str_arg(edge, "edge", ("short", "long"))
 
-        if isinstance(transform, ResizeTransform) and not transform.has_fixed_size:
-            msg = (
-                "The usage of a resize transformation that calculates the image size "
-                "at runtime is not recommended. If you experience size-mismatch "
-                "errors, consider using resize transformations with a fixed size."
-            )
-            warnings.warn(msg, RuntimeWarning)
-        self.transform: Callable = transform
+        if binarizer is None:
+            binarizer = GrayscaleToBinary()
+        self.binarizer = binarizer
 
-        if guide_transform is None and isinstance(transform, Transform):
-            guide_transform = transform + GrayscaleToBinary()
-        self.guide_transform: Callable = guide_transform
+        self.interpolation_mode = interpolation_mode
+
+    def resize(
+        self,
+        image: torch.Tensor,
+        aspect_ratio: Optional[float] = None,
+        binarize: bool = False,
+    ):
+        transform = FixedAspectRatioResize(
+            self.edge_size,
+            self.edge,
+            aspect_ratio=aspect_ratio,
+            interpolation_mode=self.interpolation_mode,
+        )
+        image = transform(image)
+        if binarize:
+            image = self.binarizer(image)
+        return image
 
     def extra_str(self) -> str:
-        extra = "num={num}", "num_steps={num_steps}", "size={size}"
-        return ", ".join(extra).format(size=self.transform.size, **self.__dict__)
+        extras = [
+            "num={num}",
+            "edge_size={edge_size}",
+            "num_steps={num_steps}",
+            "edge={edge}",
+        ]
+        if self.interpolation_mode != "bilinear":
+            extras.append("interpolation_mode={interpolation_mode}")
+        return ", ".join(extras).format(size=self.transform.size, **self.__dict__)
 
 
 class ImageOptimizerPyramid(pystiche.object):
@@ -65,22 +90,22 @@ class ImageOptimizerPyramid(pystiche.object):
         self._levels = None
 
     def build_levels(
-        self, level_image_sizes, level_steps: Union[Sequence[int], int], **kwargs
+        self,
+        level_edge_sizes: Sequence[int],
+        level_steps: Union[Sequence[int], int],
+        edges: Union[Sequence[str], str] = "short",
+        **kwargs,
     ):
+        num_levels = len(level_edge_sizes)
         if isinstance(level_steps, int):
-            level_steps = tuple([level_steps] * len(level_image_sizes))
-
-        level_transforms = [
-            Resize(level_image_size)
-            if is_image_size(level_image_size)
-            else FixedAspectRatioResize(level_image_size, **kwargs)
-            for level_image_size in level_image_sizes
-        ]
+            level_steps = [level_steps] * num_levels
+        if isinstance(edges, str):
+            edges = [edges] * num_levels
 
         levels = [
-            PyramidLevel(num, num_steps, transform)
-            for num, (num_steps, transform) in enumerate(
-                zip_equal(level_steps, level_transforms)
+            PyramidLevel(num, *level_args, **kwargs)
+            for num, level_args in enumerate(
+                zip_equal(level_edge_sizes, level_steps, edges)
             )
         ]
         self._levels = pystiche.tuple(levels)
@@ -89,28 +114,20 @@ class ImageOptimizerPyramid(pystiche.object):
     def has_levels(self) -> bool:
         return self._levels is not None
 
-    def assert_has_levels(self):
+    def _assert_has_levels(self):
         if not self.has_levels:
-            # TODO: add error message
-            raise RuntimeError
+            msg = "You need to call build_levels() before starting the optimization"
+            raise RuntimeError(msg)
 
-    @property
-    def max_level_transform(self) -> Callable:
-        self.assert_has_levels()
-        return self._levels[-1].transform
-
-    @property
-    def max_level_guide_transform(self) -> Callable:
-        self.assert_has_levels()
-        return self._levels[-1].guide_transform
+    def max_resize(self, image, **kwargs):
+        self._assert_has_levels()
+        return self._levels[-1].resize(image, **kwargs)
 
     def __call__(self, input_image: torch.Tensor, quiet: bool = False, **kwargs):
-        self.assert_has_levels()
-
+        self._assert_has_levels()
         init_states = self._extract_operator_initial_states()
-
         output_images = self._iterate(input_image, init_states, quiet, **kwargs)
-
+        self._reset_operators(init_states)
         return pystiche.tuple(output_images).detach()
 
     def _extract_operator_initial_states(self) -> Dict[Operator, InitialState]:
@@ -137,17 +154,29 @@ class ImageOptimizerPyramid(pystiche.object):
             )
         return dict(zip(operators, init_states))
 
+    def _reset_operators(self, init_states: Dict[Operator, InitialState]):
+        for operator, init_state in init_states.items():
+            if isinstance(operator, Guidance):
+                operator.set_input_guide(init_state.input_guide)
+
+            if isinstance(operator, ComparisonGuidance):
+                operator.set_target_guide(init_state.target_guide)
+
+            if isinstance(operator, Comparison):
+                operator.set_target(init_state.target_image)
+
     def _iterate(
         self,
         input_image: torch.Tensor,
         init_states: InitialState,
         quiet: bool,
-        **kwargs
+        **kwargs,
     ):
+        aspect_ratio = extract_aspect_ratio(input_image)
         output_images = [input_image]
         for level in self._levels:
-            input_image = level.transform(output_images[-1])
-            self._transform_targets(level.transform, level.guide_transform, init_states)
+            input_image = level.resize(output_images[-1], aspect_ratio=aspect_ratio)
+            self._resize_operator_images(level, init_states)
 
             if not quiet:
                 self._print_header(level.num, input_image)
@@ -159,26 +188,27 @@ class ImageOptimizerPyramid(pystiche.object):
 
         return pystiche.tuple(output_images[1:])
 
-    def _transform_targets(
-        self,
-        transform: Callable,
-        guide_transform: Callable,
-        init_states: Dict[Operator, InitialState],
+    def _resize_operator_images(
+        self, level: PyramidLevel, init_states: Dict[Operator, InitialState]
     ):
         for operator, init_state in init_states.items():
-            if isinstance(operator, Guidance) and init_state.input_guide is not None:
-                guide = guide_transform(init_state.input_guide)
+            if isinstance(operator, Guidance):
+                if init_state.input_guide is None:
+                    continue
+                guide = level.resize(init_state.input_guide, binarize=True)
                 operator.set_input_guide(guide)
 
-            if (
-                isinstance(operator, ComparisonGuidance)
-                and init_state.target_guide is not None
-            ):
-                guide = guide_transform(init_state.target_guide)
+            if isinstance(operator, ComparisonGuidance):
+                if init_state.target_guide is None:
+                    continue
+                guide = level.resize(init_state.target_guide, binarize=True)
                 operator.set_target_guide(guide)
 
-            image = transform(init_state.target_image)
-            operator.set_target(image)
+            if isinstance(operator, Comparison):
+                if init_state.target_image is None:
+                    continue
+                image = level.resize(init_state.target_image)
+                operator.set_target(image)
 
     def _print_header(self, level: int, image: torch.Tensor):
         image_size = extract_image_size(image)
@@ -192,31 +222,18 @@ class ImageOptimizerPyramid(pystiche.object):
 class ImageOptimizerOctavePyramid(ImageOptimizerPyramid):
     def build_levels(
         self,
-        size: Union[Tuple[int, int], int],
+        max_edge_size: int,
         level_steps: Union[Sequence[int], int],
         num_levels: Optional[int] = None,
         min_edge_size: int = 64,
-        edge: str = "short",
+        edges: str = "short",
+        **kwargs,
     ):
-        edge_size, aspect_ratio = self._extract_image_params(size, edge)
-
         if num_levels is None:
-            num_levels = int(np.floor(np.log2(edge_size / min_edge_size))) + 1
+            num_levels = int(np.floor(np.log2(max_edge_size / min_edge_size))) + 1
 
-        level_image_sizes = [
-            round(edge_size / (2.0 ** ((num_levels - 1) - level)))
+        level_edge_sizes = [
+            round(max_edge_size / (2.0 ** ((num_levels - 1) - level)))
             for level in range(num_levels)
         ]
-        super().build_levels(
-            level_image_sizes, level_steps, aspect_ratio=aspect_ratio, edge=edge
-        )
-
-    @staticmethod
-    def _extract_image_params(size: Union[Tuple[int, int], int], edge: str):
-        if is_image_size(size):
-            return image_to_edge_size(size, edge), calculate_aspect_ratio(size)
-        elif is_edge_size(size):
-            return size, None
-        else:
-            # FIXME: error message
-            raise ValueError
+        super().build_levels(level_edge_sizes, level_steps, edges=edges)

--- a/pystiche/papers/gatys_et_al_2017.py
+++ b/pystiche/papers/gatys_et_al_2017.py
@@ -178,25 +178,21 @@ class _GatysEtAl2017NSTPyramidBase(ImageOptimizerPyramid):
         super().__init__(nst)
         self.nst = nst
 
-    def build_levels(self, input_image, impl_params):
+    def build_levels(self, impl_params=True):
         """
         Build the levels of the pyramid. The pyramid comprises two levels with 500 and
         200 steps respectively. The images are resized so that their short edge is 500
         and 800 pixels wide.
 
         Args:
-            input_image: Image with given aspect ratio for which the levels are build
             impl_params: If True, hyper parameters from the authors implementation
                 <https://github.com/leongatys/PytorchNeuralStyleTransfer> rather than
                 the parameters given in the paper are used.
         """
-        level_image_sizes = 512 if impl_params else 500, 800
+        level_edge_sizes = 512 if impl_params else 500, 800
         level_steps = 500, 200
-        aspect_ratio = extract_aspect_ratio(input_image)
-        edge = "short"
-        super().build_levels(
-            level_image_sizes, level_steps, aspect_ratio=aspect_ratio, edge=edge
-        )
+        edges = "short"
+        super().build_levels(level_edge_sizes, level_steps, edges=edges)
 
 
 class GatysEtAl2017NSTPyramid(_GatysEtAl2017NSTPyramidBase):

--- a/pystiche/papers/li_wand_2016.py
+++ b/pystiche/papers/li_wand_2016.py
@@ -3,7 +3,6 @@ import torch
 from torch import optim
 import pystiche
 from pystiche.misc import to_engstr
-from pystiche.image import extract_image_size
 from pystiche.encoding import vgg19_encoder
 from pystiche.nst import (
     DirectEncodingComparisonOperator,
@@ -280,5 +279,9 @@ class LiWand2016NSTPyramid(ImageOptimizerOctavePyramid):
         min_edge_size = 64
         edges = "long"
         super().build_levels(
-            max_edge_size, level_steps, num_levels, min_edge_size=min_edge_size, edges=edges
+            max_edge_size,
+            level_steps,
+            num_levels,
+            min_edge_size=min_edge_size,
+            edges=edges,
         )

--- a/pystiche/papers/li_wand_2016.py
+++ b/pystiche/papers/li_wand_2016.py
@@ -263,23 +263,22 @@ class LiWand2016NSTPyramid(ImageOptimizerOctavePyramid):
         super().__init__(nst)
         self.nst = nst
 
-    def build_levels(self, input_image, impl_params):
+    def build_levels(self, impl_params):
         """
         Build the levels of the pyramid. The image size between two levels is increased
         by a factor of two. The pyramid starts with an image, which longest edge is
         atleast 64 pixels wide. On each level 100 optimization steps are performed.
 
         Args:
-            input_image: Image with given aspect ratio for which the levels are build
             impl_params: If True, hyper parameters from the authors implementation
                 <https://github.com/leongatys/PytorchNeuralStyleTransfer> rather than
                 the parameters given in the paper are used.
         """
-        image_size = extract_image_size(input_image)
+        max_edge_size = 384
         level_steps = 100 if impl_params else 200
         num_levels = 3 if impl_params else None
         min_edge_size = 64
-        edge = "long"
+        edges = "long"
         super().build_levels(
-            image_size, level_steps, num_levels, min_edge_size=min_edge_size, edge=edge
+            max_edge_size, level_steps, num_levels, min_edge_size=min_edge_size, edges=edges
         )

--- a/replication/gatys_et_al_2017.py
+++ b/replication/gatys_et_al_2017.py
@@ -28,16 +28,14 @@ def display_saving_info(output_file):
 
 
 def perform_nst(content_image, style_image, impl_params, device):
+    nst_pyramid = GatysEtAl2017NSTPyramid(impl_params).to(device)
+    nst_pyramid.build_levels(impl_params)
+
+    content_image = nst_pyramid.max_resize(content_image)
+    style_image = nst_pyramid.max_resize(style_image)
+
     utils.make_reproducible()
     input_image = utils.get_input_image("content", content_image=content_image)
-
-    nst_pyramid = GatysEtAl2017NSTPyramid(impl_params).to(device)
-    nst_pyramid.build_levels(input_image, impl_params)
-
-    transform = nst_pyramid.max_level_transform
-    content_image = transform(content_image)
-    style_image = transform(style_image)
-    input_image = transform(input_image)
 
     nst = nst_pyramid.image_optimizer
     nst.content_loss.set_target(content_image)
@@ -56,22 +54,23 @@ def figure_2(source_folder, guides_root, replication_folder, device, impl_params
         impl_params,
         device,
     ):
-        utils.make_reproducible()
-        input_image = utils.get_input_image("content", content_image=content_image)
-
         nst_pyramid = GatysEtAl2017SpatialControlNSTPyramid(
             len(guide_names), impl_params, guide_names
         )
         nst_pyramid = nst_pyramid.to(device)
-        nst_pyramid.build_levels(input_image, impl_params)
+        nst_pyramid.build_levels(impl_params)
 
-        transform = nst_pyramid.max_level_transform
-        content_image = transform(content_image)
-        style_images = [transform(image) for image in style_images]
+        content_image = nst_pyramid.max_resize(content_image)
+        style_images = [nst_pyramid.max_resize(image)
+                        for image in style_images]
 
-        guide_transform = nst_pyramid.max_level_guide_transform
-        content_guides = [guide_transform(guide) for guide in content_guides]
-        style_guides = [guide_transform(guide) for guide in style_guides]
+        content_guides = [nst_pyramid.max_resize(guide, binarize=True)
+                          for guide in content_guides]
+        style_guides = [nst_pyramid.max_resize(guide, binarize=True)
+                          for guide in style_guides]
+
+        utils.make_reproducible()
+        input_image = utils.get_input_image("content", content_image=content_image)
 
         nst = nst_pyramid.image_optimizer
         nst.content_loss.set_target(content_image)

--- a/replication/gatys_et_al_2017.py
+++ b/replication/gatys_et_al_2017.py
@@ -61,13 +61,14 @@ def figure_2(source_folder, guides_root, replication_folder, device, impl_params
         nst_pyramid.build_levels(impl_params)
 
         content_image = nst_pyramid.max_resize(content_image)
-        style_images = [nst_pyramid.max_resize(image)
-                        for image in style_images]
+        style_images = [nst_pyramid.max_resize(image) for image in style_images]
 
-        content_guides = [nst_pyramid.max_resize(guide, binarize=True)
-                          for guide in content_guides]
-        style_guides = [nst_pyramid.max_resize(guide, binarize=True)
-                          for guide in style_guides]
+        content_guides = [
+            nst_pyramid.max_resize(guide, binarize=True) for guide in content_guides
+        ]
+        style_guides = [
+            nst_pyramid.max_resize(guide, binarize=True) for guide in style_guides
+        ]
 
         utils.make_reproducible()
         input_image = utils.get_input_image("content", content_image=content_image)

--- a/replication/li_wand_2016.py
+++ b/replication/li_wand_2016.py
@@ -6,17 +6,15 @@ import utils
 
 
 def perform_nst(content_image, style_image, impl_params, device):
+    nst_pyramid = LiWand2016NSTPyramid(impl_params).to(device)
+    nst_pyramid.build_levels(impl_params)
+
+    content_image = nst_pyramid.max_resize(content_image)
+    style_image = nst_pyramid.max_resize(style_image)
+
     utils.make_reproducible()
     starting_point = "content" if impl_params else "random"
     input_image = utils.get_input_image(starting_point, content_image=content_image)
-
-    nst_pyramid = LiWand2016NSTPyramid(impl_params).to(device)
-    nst_pyramid.build_levels(input_image, impl_params)
-
-    transform = nst_pyramid.max_level_transform
-    content_image = transform(content_image)
-    style_image = transform(style_image)
-    input_image = transform(input_image)
 
     nst = nst_pyramid.image_optimizer
     nst.content_loss.set_target(content_image)


### PR DESCRIPTION
fixes #1 and supersedes #7 

---

Instead of having a fixed `Transform` for each `PyramidLevel`, each level now takes the necessary arguments to construct the transform at runtime. The resizing is now handled by the `resize()` method.

