### PR TITLE
Make impl_params a attribute of the predefined operators

### DIFF
--- a/pystiche/papers/gatys_ecker_bethge_2015.py
+++ b/pystiche/papers/gatys_ecker_bethge_2015.py
@@ -40,6 +40,8 @@ class GatysEckerBethge2015ContentLoss(DirectEncodingComparisonOperator):
     def __init__(self, encoder=None, impl_params=True):
         if encoder is None:
             encoder = get_encoder()
+        self.impl_params = impl_params
+
         name = "Content loss (direct)"
         layers = ("relu_4_2",)
         layer_weights = "sum" if impl_params else "mean"
@@ -82,6 +84,8 @@ class GatysEckerBethge2015StyleLoss(GramEncodingComparisonOperator):
     def __init__(self, encoder=None, impl_params=False):
         if encoder is None:
             encoder = get_encoder()
+        self.impl_params = impl_params
+
         name = "Style loss (Gram)"
         layers = ("relu_1_1", "relu_2_1", "relu_3_1", "relu_4_1", "relu_5_1")
         layer_weights = "sum" if impl_params else "mean"
@@ -133,6 +137,8 @@ class GatysEckerBethge2015NST(CaffePreprocessingImageOptimizer):
     """
 
     def __init__(self, impl_params=True):
+        self.impl_params = impl_params
+
         encoder = MultiOperatorEncoder(get_encoder())
         if not impl_params:
             max_to_avg_pooling(encoder)

--- a/pystiche/papers/gatys_et_al_2017.py
+++ b/pystiche/papers/gatys_et_al_2017.py
@@ -62,7 +62,11 @@ class GatysEtAl2017StyleLoss(GramEncodingComparisonOperator):
             parameters given in the paper are used.
     """
 
-    def __init__(self, encoder, impl_params=True):
+    def __init__(self, encoder=None, impl_params=True):
+        if encoder is None:
+            encoder = get_encoder()
+        self.impl_params = impl_params
+
         name = "Style loss (Gram)"
         layers = ("relu_1_1", "relu_2_1", "relu_3_1", "relu_4_1", "relu_5_1")
         layer_weights = [

--- a/pystiche/papers/gatys_et_al_2017.py
+++ b/pystiche/papers/gatys_et_al_2017.py
@@ -174,22 +174,19 @@ class GatysEtAl2017SpatialControlNST(CaffePreprocessingImageOptimizer):
 
 
 class _GatysEtAl2017NSTPyramidBase(ImageOptimizerPyramid):
-    def __init__(self, nst):
+    def __init__(self, nst, impl_params):
         super().__init__(nst)
         self.nst = nst
+        self.impl_params = impl_params
+        self.build_levels()
 
-    def build_levels(self, impl_params=True):
+    def build_levels(self):
         """
         Build the levels of the pyramid. The pyramid comprises two levels with 500 and
         200 steps respectively. The images are resized so that their short edge is 500
         and 800 pixels wide.
-
-        Args:
-            impl_params: If True, hyper parameters from the authors implementation
-                <https://github.com/leongatys/PytorchNeuralStyleTransfer> rather than
-                the parameters given in the paper are used.
         """
-        level_edge_sizes = 512 if impl_params else 500, 800
+        level_edge_sizes = 512 if self.impl_params else 500, 800
         level_steps = 500, 200
         edges = "short"
         super().build_levels(level_edge_sizes, level_steps, edges=edges)
@@ -212,7 +209,8 @@ class GatysEtAl2017NSTPyramid(_GatysEtAl2017NSTPyramidBase):
     """
 
     def __init__(self, impl_params=True):
-        super().__init__(GatysEtAl2017NST(impl_params))
+        nst = GatysEtAl2017NST(impl_params)
+        super().__init__(nst, impl_params)
 
 
 class GatysEtAl2017SpatialControlNSTPyramid(_GatysEtAl2017NSTPyramidBase):
@@ -236,4 +234,4 @@ class GatysEtAl2017SpatialControlNSTPyramid(_GatysEtAl2017NSTPyramidBase):
 
     def __init__(self, num_guides, impl_params=True, guide_names=None):
         nst = GatysEtAl2017SpatialControlNST(num_guides, impl_params, guide_names)
-        super().__init__(nst)
+        super().__init__(nst, impl_params)

--- a/pystiche/papers/li_wand_2016.py
+++ b/pystiche/papers/li_wand_2016.py
@@ -46,6 +46,8 @@ class LiWand2016ContentLoss(DirectEncodingComparisonOperator):
     def __init__(self, encoder=None, impl_params=True):
         if encoder is None:
             encoder = get_encoder()
+        self.impl_params = impl_params
+
         name = "Content loss (direct)"
         encoding_layers = ("relu_4_2",)
         layer_weights = "sum"
@@ -119,6 +121,8 @@ class LiWand2016StyleLoss(MRFEncodingComparisonOperator):
     def __init__(self, encoder=None, impl_params=True):
         if encoder is None:
             encoder = get_encoder()
+        self.impl_params = impl_params
+
         name = "Style loss (MRF)"
         encoding_layers = ("relu_3_1", "relu_4_1")
         patch_size = 3
@@ -184,6 +188,8 @@ class LiWand2016Regularizer(TotalVariationPixelRegularizationOperator):
     """
 
     def __init__(self, impl_params=True):
+        self.impl_params = impl_params
+
         name = "Regularizer (total variation)"
         exponent = 2.0
         score_weight = 1e-3
@@ -261,21 +267,18 @@ class LiWand2016NSTPyramid(ImageOptimizerOctavePyramid):
         nst = LiWand2016NST(impl_params)
         super().__init__(nst)
         self.nst = nst
+        self.impl_params = impl_params
+        self.build_levels()
 
-    def build_levels(self, impl_params):
+    def build_levels(self):
         """
         Build the levels of the pyramid. The image size between two levels is increased
         by a factor of two. The pyramid starts with an image, which longest edge is
         atleast 64 pixels wide. On each level 100 optimization steps are performed.
-
-        Args:
-            impl_params: If True, hyper parameters from the authors implementation
-            <https://github.com/chuanli11/CNNMRF> rather than the parameters given in
-            the paper are used.
         """
         max_edge_size = 384
-        level_steps = 100 if impl_params else 200
-        num_levels = 3 if impl_params else None
+        level_steps = 100 if self.impl_params else 200
+        num_levels = 3 if self.impl_params else None
         min_edge_size = 64
         edges = "long"
         super().build_levels(

--- a/replication/gatys_et_al_2017.py
+++ b/replication/gatys_et_al_2017.py
@@ -29,7 +29,6 @@ def display_saving_info(output_file):
 
 def perform_nst(content_image, style_image, impl_params, device):
     nst_pyramid = GatysEtAl2017NSTPyramid(impl_params).to(device)
-    nst_pyramid.build_levels(impl_params)
 
     content_image = nst_pyramid.max_resize(content_image)
     style_image = nst_pyramid.max_resize(style_image)
@@ -58,7 +57,6 @@ def figure_2(source_folder, guides_root, replication_folder, device, impl_params
             len(guide_names), impl_params, guide_names
         )
         nst_pyramid = nst_pyramid.to(device)
-        nst_pyramid.build_levels(impl_params)
 
         content_image = nst_pyramid.max_resize(content_image)
         style_images = [nst_pyramid.max_resize(image) for image in style_images]

--- a/replication/li_wand_2016.py
+++ b/replication/li_wand_2016.py
@@ -7,7 +7,6 @@ import utils
 
 def perform_nst(content_image, style_image, impl_params, device):
     nst_pyramid = LiWand2016NSTPyramid(impl_params).to(device)
-    nst_pyramid.build_levels(impl_params)
 
     content_image = nst_pyramid.max_resize(content_image)
     style_image = nst_pyramid.max_resize(style_image)


### PR DESCRIPTION
This makes `impl_params` direct or indirect an attribute for the following classes

- `GatysEckerBethge2015ContentLoss`
- `GatysEckerBethge2015StyleLoss`
- `GatysEckerBethge2015NST`
- `GatysEtAl2017StyleLoss`
- `GatysEtAl2017NSTPyramid`
- `GatysEtAl2017SpatialControlNSTPyramid`
- `LiWand2016ContentLoss`
- `LiWand2016StyleLoss`
- `LiWand2016Regularizer`
- `LiWand2016NSTPyramid`

Additionally, the `build_levels()` methods of the `*Pyramid`s now does not take an input argument, but instead relies on the new attribute. Furthermore,  `build_levels()` method is now called in the constructor, eliminating the need to call it manually, since all parameters are fixed anyway.