### PR TITLE
Rename nst_encoders() to multi_operator_encoders()

### DIFF
--- a/pystiche/nst/image_optimizer/image_optimizer.py
+++ b/pystiche/nst/image_optimizer/image_optimizer.py
@@ -60,7 +60,7 @@ class ImageOptimizer(pystiche.object):
         for operator in self.operators():
             operator.len_name_str = maxlen_name_str
 
-        for encoder in self.nst_encoders():
+        for encoder in self.multi_operator_encoders():
             encoder.reset_layers()
 
         for operator in self.operators(Encoding):
@@ -69,12 +69,12 @@ class ImageOptimizer(pystiche.object):
                 encoder.register_layers(operator.layers)
 
         if trim:
-            for encoder in self.nst_encoders():
+            for encoder in self.multi_operator_encoders():
                 encoder.trim()
 
         output_image = self._iterate(input_image, num_steps, quiet, print_steps)
 
-        for encoder in self.nst_encoders():
+        for encoder in self.multi_operator_encoders():
             encoder.clear_storage()
 
         return output_image.detach()
@@ -106,7 +106,7 @@ class ImageOptimizer(pystiche.object):
 
     def _closure(self, input_image: torch.Tensor, optimizer: Optimizer) -> torch.Tensor:
         optimizer.zero_grad()
-        for encoder in self.nst_encoders():
+        for encoder in self.multi_operator_encoders():
             encoder.encode(input_image)
 
         loss = sum(
@@ -152,7 +152,7 @@ class ImageOptimizer(pystiche.object):
     ) -> Iterator[Union[Encoder, MultiOperatorEncoder]]:
         return self._subclass_iterator(self._encoders, *args, **kwargs)
 
-    def nst_encoders(self) -> Iterator[MultiOperatorEncoder]:
+    def multi_operator_encoders(self) -> Iterator[MultiOperatorEncoder]:
         return self.encoders(MultiOperatorEncoder)
 
     def extra_str(self):
@@ -201,7 +201,7 @@ class PreprocessingImageOptimizer(ImageOptimizer):
 
     def _closure(self, input_image: torch.Tensor, optimizer: Optimizer) -> torch.Tensor:
         optimizer.zero_grad()
-        for encoder in self.nst_encoders():
+        for encoder in self.multi_operator_encoders():
             encoder.encode(input_image)
 
         operators = set(self.operators(Diagnosis, not_instance=True))


### PR DESCRIPTION
The `nst_encoders()` method of `ImageOptimizer` is an artifact from an earlier naming scheme. This PR renames it to `multi_operator_encoders()` for compliance with the current naming scheme.