### PR TITLE
Add Operator as postfix to operator base classes

### DIFF
--- a/pystiche/nst/image_optimizer/pyramid.py
+++ b/pystiche/nst/image_optimizer/pyramid.py
@@ -5,7 +5,12 @@ import pystiche
 from pystiche.misc import zip_equal, verify_str_arg
 from pystiche.image import extract_image_size, extract_aspect_ratio
 from pystiche.image.transforms import FixedAspectRatioResize, GrayscaleToBinary
-from ..operators import Operator, Comparison, Guidance, ComparisonGuidance
+from ..operators import (
+    Operator,
+    ComparisonOperator,
+    GuidanceOperator,
+    ComparisonGuidanceOperator,
+)
 from .image_optimizer import ImageOptimizer
 
 __all__ = ["PyramidLevel", "ImageOptimizerPyramid", "ImageOptimizerOctavePyramid"]
@@ -118,17 +123,18 @@ class ImageOptimizerPyramid(pystiche.object):
         init_states = []
         for operator in operators:
             has_input_guide = (
-                isinstance(operator, Guidance) and operator.has_input_guide
+                isinstance(operator, GuidanceOperator) and operator.has_input_guide
             )
             input_guide = operator.input_guide if has_input_guide else None
 
             has_target_guide = (
-                isinstance(operator, ComparisonGuidance) and operator.has_target_guide
+                isinstance(operator, ComparisonGuidanceOperator)
+                and operator.has_target_guide
             )
             target_guide = operator.target_guide if has_target_guide else None
 
             has_target_image = (
-                isinstance(operator, Comparison) and operator.has_target_image
+                isinstance(operator, ComparisonOperator) and operator.has_target_image
             )
             target_image = operator.target_image if has_target_image else None
 
@@ -139,13 +145,13 @@ class ImageOptimizerPyramid(pystiche.object):
 
     def _reset_operators(self, init_states: Dict[Operator, InitialState]):
         for operator, init_state in init_states.items():
-            if isinstance(operator, Guidance):
+            if isinstance(operator, GuidanceOperator):
                 operator.set_input_guide(init_state.input_guide)
 
-            if isinstance(operator, ComparisonGuidance):
+            if isinstance(operator, ComparisonGuidanceOperator):
                 operator.set_target_guide(init_state.target_guide)
 
-            if isinstance(operator, Comparison):
+            if isinstance(operator, ComparisonOperator):
                 operator.set_target(init_state.target_image)
 
     def _iterate(
@@ -175,19 +181,19 @@ class ImageOptimizerPyramid(pystiche.object):
         self, level: PyramidLevel, init_states: Dict[Operator, InitialState]
     ):
         for operator, init_state in init_states.items():
-            if isinstance(operator, Guidance):
+            if isinstance(operator, GuidanceOperator):
                 if init_state.input_guide is None:
                     continue
                 guide = level.resize(init_state.input_guide, binarize=True)
                 operator.set_input_guide(guide)
 
-            if isinstance(operator, ComparisonGuidance):
+            if isinstance(operator, ComparisonGuidanceOperator):
                 if init_state.target_guide is None:
                     continue
                 guide = level.resize(init_state.target_guide, binarize=True)
                 operator.set_target_guide(guide)
 
-            if isinstance(operator, Comparison):
+            if isinstance(operator, ComparisonOperator):
                 if init_state.target_image is None:
                     continue
                 image = level.resize(init_state.target_image)

--- a/pystiche/nst/operators/_base.py
+++ b/pystiche/nst/operators/_base.py
@@ -9,24 +9,24 @@ from pystiche.encoding import Encoder
 
 __all__ = [
     "Operator",
-    "Diagnosis",
-    "Comparison",
-    "Regularization",
-    "Encoding",
-    "Pixel",
+    "DiagnosisOperator",
+    "ComparisonOperator",
+    "RegularizationOperator",
+    "EncodingOperator",
+    "PixelOperator",
     "EncodingComparisonOperator",
     "EncodingRegularizationOperator",
     "PixelComparisonOperator",
     "PixelRegularizationOperator",
-    "Guidance",
-    "ComparisonGuidance",
-    "RegularizationGuidance",
-    "EncodingGuidance",
-    "PixelGuidance",
-    "GuidedEncodingComparison",
-    "GuidedEncodingRegularization",
-    "GuidedPixelComparison",
-    "GuidedPixelRegularization",
+    "GuidanceOperator",
+    "ComparisonGuidanceOperator",
+    "RegularizationGuidanceOperator",
+    "EncodingGuidanceOperator",
+    "PixelGuidanceOperator",
+    "GuidedEncodingComparisonOperator",
+    "GuidedEncodingRegularizationOperator",
+    "GuidedPixelComparisonOperator",
+    "GuidedPixelRegularizationOperator",
 ]
 
 
@@ -94,12 +94,12 @@ class Operator(pystiche.object):
         pass
 
 
-class Diagnosis(Operator):
+class DiagnosisOperator(Operator):
     def __call__(self, input_image: torch.Tensor):
         super().__call__(input_image)
 
 
-class Comparison(Operator):
+class ComparisonOperator(Operator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.target_image = None
@@ -138,7 +138,7 @@ class Comparison(Operator):
         pass
 
 
-class Regularization(Operator):
+class RegularizationOperator(Operator):
     @abstractmethod
     def forward(self, input_image: torch.Tensor) -> torch.Tensor:
         pass
@@ -152,7 +152,7 @@ class Regularization(Operator):
         pass
 
 
-class Encoding(Operator):
+class EncodingOperator(Operator):
     def __init__(
         self,
         encoder: Encoder,
@@ -198,13 +198,13 @@ class Encoding(Operator):
         pass
 
 
-class Pixel(Operator):
+class PixelOperator(Operator):
     @abstractmethod
     def forward(self, input_image: torch.Tensor) -> torch.Tensor:
         pass
 
 
-class EncodingComparisonOperator(Encoding, Comparison):
+class EncodingComparisonOperator(EncodingOperator, ComparisonOperator):
     def forward(self, input_image: torch.Tensor) -> torch.Tensor:
         target_reprs, ctxs = self._target_repr, self._ctx
         input_reprs = self._process_input(input_image, ctxs)
@@ -253,7 +253,7 @@ class EncodingComparisonOperator(Encoding, Comparison):
         pass
 
 
-class EncodingRegularizationOperator(Encoding, Regularization):
+class EncodingRegularizationOperator(EncodingOperator, RegularizationOperator):
     def forward(self, input_image: torch.Tensor) -> torch.Tensor:
         input_reprs = self._process_input(input_image)
 
@@ -281,7 +281,7 @@ class EncodingRegularizationOperator(Encoding, Regularization):
         pass
 
 
-class PixelComparisonOperator(Pixel, Comparison):
+class PixelComparisonOperator(PixelOperator, ComparisonOperator):
     def forward(self, input_image: torch.Tensor) -> torch.Tensor:
         target_repr, ctx = self._target_repr, self._ctx
         input_repr = self._process_input(input_image, ctx)
@@ -311,7 +311,7 @@ class PixelComparisonOperator(Pixel, Comparison):
         pass
 
 
-class PixelRegularizationOperator(Pixel, Regularization):
+class PixelRegularizationOperator(PixelOperator, RegularizationOperator):
     def forward(self, input_image: torch.Tensor) -> torch.Tensor:
         input_repr = self._process_input(input_image)
 
@@ -331,7 +331,7 @@ class PixelRegularizationOperator(Pixel, Regularization):
         pass
 
 
-class Guidance(Operator):
+class GuidanceOperator(Operator):
     def __init__(self, name: str, method: str = "simple", **kwargs) -> None:
         super().__init__(name, **kwargs)
         self.input_guide = None
@@ -348,7 +348,7 @@ class Guidance(Operator):
         return self.input_guide is not None
 
 
-class ComparisonGuidance(Guidance, Comparison):
+class ComparisonGuidanceOperator(GuidanceOperator, ComparisonOperator):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.target_guide = None
@@ -361,11 +361,11 @@ class ComparisonGuidance(Guidance, Comparison):
         return self.target_guide is not None
 
 
-class RegularizationGuidance(Guidance, Regularization):
+class RegularizationGuidanceOperator(GuidanceOperator, RegularizationOperator):
     pass
 
 
-class EncodingGuidance(Guidance, Encoding):
+class EncodingGuidanceOperator(GuidanceOperator, EncodingOperator):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._input_enc_guides = None
@@ -390,12 +390,12 @@ class EncodingGuidance(Guidance, Encoding):
         return self._input_enc_guides is not None
 
 
-class PixelGuidance(Guidance, Pixel):
+class PixelGuidanceOperator(GuidanceOperator, PixelOperator):
     pass
 
 
-class GuidedEncodingComparison(
-    EncodingGuidance, ComparisonGuidance, EncodingComparisonOperator
+class GuidedEncodingComparisonOperator(
+    EncodingGuidanceOperator, ComparisonGuidanceOperator, EncodingComparisonOperator
 ):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -426,7 +426,9 @@ class GuidedEncodingComparison(
         return self._target_enc_guides is not None
 
 
-class GuidedPixelComparison(PixelGuidance, ComparisonGuidance, PixelComparisonOperator):
+class GuidedPixelComparisonOperator(
+    PixelGuidanceOperator, ComparisonGuidanceOperator, PixelComparisonOperator
+):
     def _input_image_to_repr(self, image: torch.Tensor, ctx: Any) -> Any:
         if self.has_input_guide:
             image = self._apply_guide(image, self.input_guide)
@@ -438,8 +440,10 @@ class GuidedPixelComparison(PixelGuidance, ComparisonGuidance, PixelComparisonOp
         return super()._target_image_to_repr(image)
 
 
-class GuidedEncodingRegularization(
-    EncodingGuidance, RegularizationGuidance, EncodingRegularizationOperator
+class GuidedEncodingRegularizationOperator(
+    EncodingGuidanceOperator,
+    RegularizationGuidanceOperator,
+    EncodingRegularizationOperator,
 ):
     def _input_encs_to_reprs(self, encs: Sequence[torch.Tensor]) -> Sequence[Any]:
         if self.has_input_enc_guides:
@@ -447,8 +451,8 @@ class GuidedEncodingRegularization(
         return super()._input_encs_to_reprs(encs)
 
 
-class GuidedPixelRegularization(
-    PixelGuidance, RegularizationGuidance, PixelRegularizationOperator
+class GuidedPixelRegularizationOperator(
+    PixelGuidanceOperator, RegularizationGuidanceOperator, PixelRegularizationOperator
 ):
     def _input_image_to_repr(self, image: torch.Tensor) -> Any:
         if self.has_input_guide:

--- a/pystiche/nst/operators/guidance.py
+++ b/pystiche/nst/operators/guidance.py
@@ -1,10 +1,10 @@
-from ._base import GuidedEncodingComparison
+from ._base import GuidedEncodingComparisonOperator
 from .encoding import GramEncodingComparisonOperator
 
 __all__ = ["GuidedGramEncodingComparisonOperator"]
 
 
 class GuidedGramEncodingComparisonOperator(
-    GuidedEncodingComparison, GramEncodingComparisonOperator
+    GuidedEncodingComparisonOperator, GramEncodingComparisonOperator
 ):
     pass

--- a/pystiche/papers/gatys_et_al_2017.py
+++ b/pystiche/papers/gatys_et_al_2017.py
@@ -7,7 +7,7 @@ from pystiche.encoding import vgg19_encoder
 from pystiche.nst import (
     DirectEncodingComparisonOperator,
     GramEncodingComparisonOperator,
-    GuidedEncodingComparison,
+    GuidedEncodingComparisonOperator,
     MultiOperatorEncoder,
     CaffePreprocessingImageOptimizer,
     ImageOptimizerPyramid,
@@ -97,7 +97,7 @@ class GatysEtAl2017StyleLoss(GramEncodingComparisonOperator):
 
 
 class GatysEtAl2017SpatialControlStyleLoss(
-    GuidedEncodingComparison, GatysEtAl2017StyleLoss
+    GuidedEncodingComparisonOperator, GatysEtAl2017StyleLoss
 ):
     r"""Spatially guided style loss based on gram matrices from
     `"Controlling Perceptual Factors in Neural Style Transfer" <http://openaccess.thecvf.com/content_cvpr_2017/papers/Gatys_Controlling_Perceptual_Factors_CVPR_2017_paper.pdf>`


### PR DESCRIPTION
This adds the postfix `Operator` to the following operator base classes, to better reflect their nature:

- `DiagnosisOperator`
- `ComparisonOperator`
- `RegularizationOperator`
- `EncodingOperator`
- `PixelOperator`
- `GuidanceOperator`
- `ComparisonGuidanceOperator`
- `RegularizationGuidanceOperator`
- `EncodingGuidanceOperator`
- `PixelGuidanceOperator`
- `GuidedEncodingComparisonOperator`
- `GuidedEncodingRegularizationOperator`
- `GuidedPixelComparisonOperator`
- `GuidedPixelRegularizationOperator`