### PR TITLE
FIx pillow import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, find_packages
 requirements = (
     "numpy",
     "torch >= 1.2.0",
+    "pillow <= 6.2.0",
     "torchvision >= 0.4.0",
 )
 


### PR DESCRIPTION
`torchvision==0.4.2` relies on the constant `PILLOW_VERSION`, which was removed in `pillow==7.0.0`. Thus, if both current versions are installed `torchvision` errors during import. This is a [known bug](https://github.com/pytorch/vision/issues/1712) and will be fixed in the next release. For `pystiche` this is temporarily fixed by including `pillow<=6.2.0` in the required packages.