### PR TITLE
Fix interface of MultiOperatorEncoder

### DIFF
--- a/pystiche/nst/encoder.py
+++ b/pystiche/nst/encoder.py
@@ -39,6 +39,12 @@ class MultiOperatorEncoder(pystiche.object):
 
         return pystiche.tuple([storage[name] for name in layers])
 
+    def verify_layers(self, layers: Sequence[str]):
+        return self._encoder(layers)
+
+    def __contains__(self, name: str) -> bool:
+        return self._encoder.__contains__(name)
+
     def trim(self):
         self._encoder.trim(self.layers)
 


### PR DESCRIPTION
This adds the interface for the `verify_layers()` as well as `__contains__()` methods of the underlying `Encoder`.