### PR TITLE
fixed pillow import

### DIFF
--- a/pystiche/image/io.py
+++ b/pystiche/image/io.py
@@ -36,6 +36,6 @@ def write_image(
 
 
 def show_image(
-    image: torch.Tensor, mode: Optional[str] = None, title: Optional[str] = None,
+    image: torch.Tensor, mode: Optional[str] = None, title: Optional[str] = None
 ):
     export_to_pil(image, mode=mode).show(title=title)

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,6 @@
 from setuptools import setup, find_packages
 
-requirements = (
-    "numpy",
-    "torch >= 1.2.0",
-    "pillow <= 6.2.0",
-    "torchvision >= 0.4.0",
-)
+requirements = ("numpy", "torch >= 1.2.0", "pillow < 7.0.0", "torchvision >= 0.4.0")
 
 testing_requires = (
     "pyimagetest@https://github.com/pmeier/pyimagetest/archive/master.zip",


### PR DESCRIPTION
Corrects #29 

Change the required `pillow` version from `<= 6.2.0` to `< 7.0.0` to include the most recent versions in between.