### PR TITLE
fix UserWarning for changes in align_corners default value

### DIFF
--- a/pystiche/image/transforms/functional/_utils.py
+++ b/pystiche/image/transforms/functional/_utils.py
@@ -1,0 +1,13 @@
+from typing import Optional
+
+__all__ = ["get_align_corners"]
+
+
+# this method should only be used as long as interpolate(), grid_sample(), and
+# affine_grid() from torch.nn.functional raise a UserWarning for changed default
+# behaviour
+def get_align_corners(interpolation_mode: str) -> Optional[bool]:
+    if interpolation_mode in ("nearest", "area"):
+        return None
+    else:
+        return False

--- a/pystiche/image/transforms/functional/misc.py
+++ b/pystiche/image/transforms/functional/misc.py
@@ -7,6 +7,7 @@ from torchvision.transforms.functional import (
     to_pil_image as _to_pil_image,
 )
 from pystiche.typing import Numeric
+from ._utils import get_align_corners
 
 __all__ = [
     "import_from_pil",
@@ -53,17 +54,12 @@ def normalize(x: torch.Tensor, mean: Numeric, std: Numeric) -> torch.Tensor:
 def resize(
     x: torch.Tensor, size: Sequence[int], interpolation_mode: str = "bilinear"
 ) -> torch.Tensor:
-    if interpolation_mode in ("nearest", "area"):
-        align_corners = None
-    else:
-        align_corners = False
-
     return interpolate(
         x,
         size=size,
         scale_factor=None,
         mode=interpolation_mode,
-        align_corners=align_corners,
+        align_corners=get_align_corners(interpolation_mode),
     )
 
 


### PR DESCRIPTION
The `UserWarning` is raised by `F.interpolate()`, `F.grid_sample()`, and `F.affine_grid()` where `F = torch.nn.functional`. This can be removed again if the warning is removed by `torch` in the future.