### PR TITLE
Refactor custom __str__ of pystiche.Module

### DIFF
--- a/pystiche/_base.py
+++ b/pystiche/_base.py
@@ -28,7 +28,7 @@ class Module(ABC, nn.Module):
             named_children = tuple(self.named_children())
 
         return build_obj_str(
-            name=name,
+            name,
             description=description,
             named_children=named_children,
             num_indent=self._STR_INDENT,

--- a/pystiche/_base.py
+++ b/pystiche/_base.py
@@ -1,17 +1,13 @@
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Sequence, Tuple, Dict, NoReturn
+from typing import Any, Optional, Sequence, Tuple, Dict, Iterator, NoReturn
 from collections import OrderedDict
 import torch
 from torch import nn
-from .misc import build_obj_str, to_engstr
+from .misc import build_obj_str
 
 
-class Module(ABC, nn.Module):
+class Object(ABC):
     _STR_INDENT = 2
-
-    @abstractmethod
-    def forward(self, *args: Any, **kwargs: Dict[str, Any]) -> Any:
-        pass
 
     def _properties(self) -> Dict[str, Any]:
         return OrderedDict()
@@ -23,6 +19,18 @@ class Module(ABC, nn.Module):
         dct = self._properties()
         dct.update(self.extra_properties())
         return dct
+
+    def _named_children(self) -> Iterator[Tuple[str, Any]]:
+        return
+        yield
+
+    def extra_named_children(self) -> Iterator[Tuple[str, Any]]:
+        return
+        yield
+
+    def named_children(self) -> Iterator[Tuple[str, Any]]:
+        yield from self._named_children()
+        yield from self.extra_named_children()
 
     def _build_str(
         self,
@@ -49,11 +57,17 @@ class Module(ABC, nn.Module):
     def __str__(self) -> str:
         return self._build_str()
 
+
+class Module(nn.Module, Object):
+    @abstractmethod
+    def forward(self, *args: Any, **kwargs: Dict[str, Any]) -> Any:
+        pass
+
     def extra_repr(self) -> str:
         return ", ".join([f"{key}={value}" for key, value in self.properties().items()])
 
 
-class TensorStorage(nn.Module):
+class TensorStorage(nn.Module, Object):
     def __init__(self, **attrs: Dict[str, Any]) -> None:
         super().__init__()
         for name, attr in attrs.items():

--- a/pystiche/_base.py
+++ b/pystiche/_base.py
@@ -1,17 +1,23 @@
-from abc import abstractmethod
-from typing import Any, Dict, NoReturn
+from abc import ABC, abstractmethod
+from typing import Any, Optional, Sequence, Tuple, Dict, NoReturn
 import torch
 from torch import nn
+from .misc import build_obj_str
 
 
-class Module(nn.Module):
+class Module(ABC, nn.Module):
     _STR_INDENT = 2
 
     @abstractmethod
     def forward(self, *args: Any, **kwargs: Dict[str, Any]) -> Any:
         pass
 
-    def _build_str(self, name=None, description=None, named_children=None):
+    def _build_str(
+        self,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        named_children: Optional[Sequence[Tuple[str, Any]]] = None,
+    ) -> str:
         if name is None:
             name = self.__class__.__name__
 
@@ -21,29 +27,12 @@ class Module(nn.Module):
         if named_children is None:
             named_children = tuple(self.named_children())
 
-        prefix = f"{name}("
-        postfix = ")"
-
-        description_lines = description.splitlines()
-        multi_line_descr = len(description_lines) > 1
-
-        if not named_children and not multi_line_descr:
-            return prefix + description + postfix
-
-        def indent(line):
-            return " " * self._STR_INDENT + line
-
-        body = []
-        for line in description_lines:
-            body.append(indent(line))
-
-        for name, module in named_children:
-            lines = str(module).splitlines()
-            body.append(indent(f"({name}): {lines[0]}"))
-            for line in lines[1:]:
-                body.append(indent(line))
-
-        return "\n".join([prefix] + body + [postfix])
+        return build_obj_str(
+            name=name,
+            description=description,
+            named_children=named_children,
+            num_indent=self._STR_INDENT,
+        )
 
     def __str__(self) -> str:
         return self._build_str()

--- a/pystiche/_base.py
+++ b/pystiche/_base.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Any, Optional, Sequence, Tuple, Dict, NoReturn
 from collections import OrderedDict
-import itertools
 import torch
 from torch import nn
 from .misc import build_obj_str, to_engstr
@@ -14,13 +13,16 @@ class Module(ABC, nn.Module):
     def forward(self, *args: Any, **kwargs: Dict[str, Any]) -> Any:
         pass
 
-    def _properties(self) -> Dict[str, str]:
-        dct = OrderedDict()
-        dct["score_weight"] = to_engstr(self.score_weight)
-        return dct
-
-    def extra_properties(self) -> Dict[str, str]:
+    def _properties(self) -> Dict[str, Any]:
         return OrderedDict()
+
+    def extra_properties(self) -> Dict[str, Any]:
+        return OrderedDict()
+
+    def properties(self) -> Dict[str, Any]:
+        dct = self._properties()
+        dct.update(self.extra_properties())
+        return dct
 
     def _build_str(
         self,
@@ -32,8 +34,7 @@ class Module(ABC, nn.Module):
             name = self.__class__.__name__
 
         if properties is None:
-            properties = self._properties()
-            properties.update(self.extra_properties())
+            properties = self.properties()
 
         if named_children is None:
             named_children = tuple(self.named_children())
@@ -49,14 +50,7 @@ class Module(ABC, nn.Module):
         return self._build_str()
 
     def extra_repr(self) -> str:
-        return ", ".join(
-            [
-                f"{key}={value}"
-                for key, value in itertools.chain(
-                    self._properties().items(), self.extra_properties().items()
-                )
-            ]
-        )
+        return ", ".join([f"{key}={value}" for key, value in self.properties().items()])
 
 
 class TensorStorage(nn.Module):

--- a/pystiche/_base.py
+++ b/pystiche/_base.py
@@ -1,8 +1,10 @@
 from abc import ABC, abstractmethod
 from typing import Any, Optional, Sequence, Tuple, Dict, NoReturn
+from collections import OrderedDict
+import itertools
 import torch
 from torch import nn
-from .misc import build_obj_str
+from .misc import build_obj_str, to_engstr
 
 
 class Module(ABC, nn.Module):
@@ -12,24 +14,33 @@ class Module(ABC, nn.Module):
     def forward(self, *args: Any, **kwargs: Dict[str, Any]) -> Any:
         pass
 
+    def _properties(self) -> Dict[str, str]:
+        dct = OrderedDict()
+        dct["score_weight"] = to_engstr(self.score_weight)
+        return dct
+
+    def extra_properties(self) -> Dict[str, str]:
+        return OrderedDict()
+
     def _build_str(
         self,
         name: Optional[str] = None,
-        description: Optional[str] = None,
+        properties: Optional[Dict[str, str]] = None,
         named_children: Optional[Sequence[Tuple[str, Any]]] = None,
     ) -> str:
         if name is None:
             name = self.__class__.__name__
 
-        if description is None:
-            description = self.description()
+        if properties is None:
+            properties = self._properties()
+            properties.update(self.extra_properties())
 
         if named_children is None:
             named_children = tuple(self.named_children())
 
         return build_obj_str(
             name,
-            description=description,
+            properties=properties,
             named_children=named_children,
             num_indent=self._STR_INDENT,
         )
@@ -37,11 +48,15 @@ class Module(ABC, nn.Module):
     def __str__(self) -> str:
         return self._build_str()
 
-    def description(self) -> str:
-        return ""
-
     def extra_repr(self) -> str:
-        return self.description()
+        return ", ".join(
+            [
+                f"{key}={value}"
+                for key, value in itertools.chain(
+                    self._properties().items(), self.extra_properties().items()
+                )
+            ]
+        )
 
 
 class TensorStorage(nn.Module):

--- a/pystiche/_base.py
+++ b/pystiche/_base.py
@@ -6,6 +6,9 @@ from torch import nn
 from .misc import build_obj_str
 
 
+__all__ = ["Object", "Module", "TensorStorage"]
+
+
 class Object(ABC):
     _STR_INDENT = 2
 

--- a/pystiche/enc/encoder.py
+++ b/pystiche/enc/encoder.py
@@ -40,7 +40,7 @@ class SingleLayerEncoder(Encoder):
             description += ", " + extra_description
         named_children = ()
         return self._build_str(
-            name=name, description=description, named_children=named_children
+            name, description=description, named_children=named_children
         )
 
 

--- a/pystiche/enc/encoder.py
+++ b/pystiche/enc/encoder.py
@@ -23,24 +23,23 @@ class Encoder(pystiche.Module):
 class SingleLayerEncoder(Encoder):
     def __init__(self, multi_layer_encoder: "MultiLayerEncoder", layer: str):
         super().__init__()
-        self._multi_layer_encoder = multi_layer_encoder
+        self.multi_layer_encoder = multi_layer_encoder
         self.layer = layer
 
     def forward(self, input_image: torch.Tensor) -> torch.Tensor:
-        return self._multi_layer_encoder(input_image, layers=(self.layer,))[0]
+        return self.multi_layer_encoder(input_image, layers=(self.layer,))[0]
 
     def propagate_guide(self, guide: torch.Tensor) -> torch.Tensor:
-        return self._multi_layer_encoder.propagate_guide(guide, layers=(self.layer,))[0]
+        return self.multi_layer_encoder.propagate_guide(guide, layers=(self.layer,))[0]
 
     def __str__(self) -> str:
-        name = self._multi_layer_encoder.__class__.__name__
-        description = f"layer={self.layer}"
-        extra_description = self._multi_layer_encoder.description()
-        if extra_description:
-            description += ", " + extra_description
+        name = self.multi_layer_encoder.__class__.__name__
+        properties = OrderedDict()
+        properties["layer"] = self.layer
+        properties.update(self.multi_layer_encoder.properties())
         named_children = ()
         return self._build_str(
-            name, description=description, named_children=named_children
+            name=name, properties=properties, named_children=named_children
         )
 
 

--- a/pystiche/enc/models/alexnet.py
+++ b/pystiche/enc/models/alexnet.py
@@ -45,13 +45,14 @@ class AlexNetEncoder(MultiLayerEncoder):
 
             modules[name] = module
 
-    def description(self):
-        extras = [f"weights={self.weights}"]
-        if not self.preprocessing:
-            extras.append(f"preprocessing={self.preprocessing}")
+    def extra_properties(self):
+        dct = OrderedDict()
+        dct["weights"] = self.weights
+        if not self.internal_preprocessing:
+            dct["internal_preprocessing"] = self.internal_preprocessing
         if self.allow_inplace:
-            extras.append(f"allow_inplace={self.allow_inplace}")
-        return ",".join(extras)
+            dct["allow_inplace"] = self.allow_inplace
+        return dct
 
 
 def alexnet_encoder(

--- a/pystiche/enc/models/vgg.py
+++ b/pystiche/enc/models/vgg.py
@@ -81,13 +81,15 @@ class VGGEncoder(MultiLayerEncoder):
 
         return modules
 
-    def description(self):
-        extras = [f"arch={self.arch}, " f"weights={self.weights}"]
+    def extra_properties(self):
+        dct = OrderedDict()
+        dct["arch"] = self.arch
+        dct["weights"] = self.weights
         if not self.internal_preprocessing:
-            extras.append(f"internal_preprocessing={self.internal_preprocessing}")
+            dct["internal_preprocessing"] = self.internal_preprocessing
         if self.allow_inplace:
-            extras.append(f"allow_inplace={self.allow_inplace}")
-        return ", ".join(extras)
+            dct["allow_inplace"] = self.allow_inplace
+        return dct
 
 
 def _vgg_encoder(

--- a/pystiche/loss/multi_op_loss.py
+++ b/pystiche/loss/multi_op_loss.py
@@ -38,7 +38,7 @@ class MultiOperatorLoss(pystiche.Module):
         for op in encoding_ops():
             encoder = op.encoder
             if isinstance(encoder, SingleLayerEncoder):
-                multi_layer_encoders.add(encoder._multi_layer_encoder)
+                multi_layer_encoders.add(encoder.multi_layer_encoder)
 
         return tuple(multi_layer_encoders)
 

--- a/pystiche/misc.py
+++ b/pystiche/misc.py
@@ -159,3 +159,34 @@ def verify_str_arg(
         raise ValueError(msg1 + msg2)
 
     return arg
+
+
+def build_obj_str(
+    name: str,
+    description: str = "",
+    named_children: Sequence[Tuple[str, Any]] = (),
+    num_indent: int = 2,
+):
+    prefix = f"{name}("
+    postfix = ")"
+
+    description_lines = description.splitlines()
+    multi_line_descr = len(description_lines) > 1
+
+    if not named_children and not multi_line_descr:
+        return prefix + description + postfix
+
+    def indent(line):
+        return " " * num_indent + line
+
+    body = []
+    for line in description_lines:
+        body.append(indent(line))
+
+    for name, module in named_children:
+        lines = str(module).splitlines()
+        body.append(indent(f"({name}): {lines[0]}"))
+        for line in lines[1:]:
+            body.append(indent(line))
+
+    return "\n".join([prefix] + body + [postfix])

--- a/pystiche/misc.py
+++ b/pystiche/misc.py
@@ -179,13 +179,14 @@ def build_obj_str(
     multiline_properties = any(
         [len(str(value).splitlines()) > 1 for value in properties.values()]
     )
+
     if not multiline_properties and num_properties < properties_threshold:
         properties = ", ".join([f"{key}={value}" for key, value in properties.items()])
 
         if not named_children:
             return prefix + properties + postfix
     else:
-        properties = format_dict(properties, sep="=")
+        properties = ",\n".join([f"{key}={value}" for key, value in properties.items()])
 
     def indent(line):
         return " " * num_indent + line

--- a/pystiche/misc.py
+++ b/pystiche/misc.py
@@ -164,7 +164,7 @@ def verify_str_arg(
 
 def build_obj_str(
     name: str,
-    properties: Dict[str, str] = None,
+    properties: Dict[str, Any] = None,
     named_children: Sequence[Tuple[str, Any]] = (),
     properties_threshold: int = 4,
     num_indent: int = 2,
@@ -177,7 +177,7 @@ def build_obj_str(
 
     num_properties = len(properties)
     multiline_properties = any(
-        [len(value.splitlines()) > 1 for value in properties.values()]
+        [len(str(value).splitlines()) > 1 for value in properties.values()]
     )
     if not multiline_properties and num_properties < properties_threshold:
         properties = ", ".join([f"{key}={value}" for key, value in properties.items()])

--- a/pystiche/misc.py
+++ b/pystiche/misc.py
@@ -200,3 +200,8 @@ def build_obj_str(
             body.append(indent(line))
 
     return "\n".join([prefix] + body + [postfix])
+
+
+def is_almost(actual: float, desired:float, eps=1e-6):
+    return abs(actual - desired) < eps
+

--- a/pystiche/misc.py
+++ b/pystiche/misc.py
@@ -202,6 +202,5 @@ def build_obj_str(
     return "\n".join([prefix] + body + [postfix])
 
 
-def is_almost(actual: float, desired:float, eps=1e-6):
+def is_almost(actual: float, desired: float, eps=1e-6):
     return abs(actual - desired) < eps
-

--- a/pystiche/ops/comparison.py
+++ b/pystiche/ops/comparison.py
@@ -33,7 +33,7 @@ class GramOperator(EncodingComparisonOperator):
         self, encoder: Encoder, normalize: bool = True, score_weight: float = 1.0
     ) -> None:
         super().__init__(encoder, score_weight=score_weight)
-        self.normalize = normalize  # FIXME: add to description
+        self.normalize = normalize
 
     def enc_to_repr(self, enc: torch.Tensor) -> torch.Tensor:
         x = torch.flatten(enc, 2)
@@ -52,6 +52,12 @@ class GramOperator(EncodingComparisonOperator):
         self, input_repr: torch.Tensor, target_repr: torch.Tensor, ctx: None
     ) -> torch.Tensor:
         return F.mse_loss(input_repr, target_repr)
+
+    def _properties(self):
+        dct = super()._properties()
+        if not self.normalize:
+            dct["normalize"] = self.normalize
+        return dct
 
 
 class MRFOperator(EncodingComparisonOperator):
@@ -122,14 +128,15 @@ class MRFOperator(EncodingComparisonOperator):
     ) -> torch.Tensor:
         return F.patch_matching_loss(input_repr, target_repr)
 
-    # def _descriptions(self) -> Dict[str, Any]:
-    #     dct = super()._descriptions()
-    #     dct["Patch size"] = self.patch_size
-    #     dct["Stride"] = self.stride
-    #     if self.num_scale_steps > 0:
-    #         dct["Number of scale steps"] = self.num_scale_steps
-    #         dct["Scale step width"] = f"{self.scale_step_width:.1%}"
-    #     if self.num_rotation_steps > 0:
-    #         dct["Number of rotation steps"] = self.num_rotation_steps
-    #         dct["Rotation step width"] = f"{self.rotation_step_width:.1f}°"
-    #     return dct
+    def _properties(self):
+        dct = super()._properties()
+        dct["patch_size"] = self.patch_size
+        dct["stride"] = self.stride
+        if self.num_scale_steps > 0:
+            dct["num_scale_steps"] = self.num_scale_steps
+            dct["scale_step_width"] = f"{self.scale_step_width:.1%}"
+        if self.num_rotation_steps > 0:
+            dct["num_rotation_steps"] = self.num_rotation_steps
+            dct["rotation_step_width"] = f"{self.rotation_step_width:.1f}°"
+        return dct
+

--- a/pystiche/ops/comparison.py
+++ b/pystiche/ops/comparison.py
@@ -139,4 +139,3 @@ class MRFOperator(EncodingComparisonOperator):
             dct["num_rotation_steps"] = self.num_rotation_steps
             dct["rotation_step_width"] = f"{self.rotation_step_width:.1f}°"
         return dct
-

--- a/pystiche/ops/container.py
+++ b/pystiche/ops/container.py
@@ -1,6 +1,7 @@
 from typing import Union, Sequence, Callable
 from collections import OrderedDict
 import torch
+from pystiche.misc import build_obj_str
 from pystiche.enc import Encoder, MultiLayerEncoder
 from .op import Operator, EncodingOperator, ComparisonOperator
 from .guidance import Guidance, ComparisonGuidance
@@ -96,9 +97,7 @@ class MultiLayerEncodingOperator(CompoundOperator):
             (name, f"{module.__class__.__name__}({module.description()})")
             for name, module in self.named_children()
         ]
-        return self._build_str(
-            description=self.description(), named_children=named_children
-        )
+        return self._build_str(named_children=named_children)
 
     def description(self) -> str:
         return self._description

--- a/pystiche/ops/container.py
+++ b/pystiche/ops/container.py
@@ -102,12 +102,13 @@ class MultiLayerEncodingOperator(CompoundOperator):
             del properties["encoder"]
             return op._build_str(properties=properties, named_children=())
 
-
         properties = OrderedDict()
         properties["encoder"] = build_encoder_str()
         properties.update(self.properties())
 
-        named_children = [(name, build_op_str(op)) for name, op in self.named_children()]
+        named_children = [
+            (name, build_op_str(op)) for name, op in self.named_children()
+        ]
 
         return self._build_str(properties=properties, named_children=named_children)
 

--- a/pystiche/ops/container.py
+++ b/pystiche/ops/container.py
@@ -55,11 +55,6 @@ class MultiLayerEncodingOperator(CompoundOperator):
             ]
         )
 
-        self._description = (
-            f"{multi_layer_encoder.__class__.__name__}"
-            f"({multi_layer_encoder.description()})"
-        )
-
         super().__init__(ops, score_weight=score_weight)
 
     @staticmethod
@@ -93,14 +88,28 @@ class MultiLayerEncodingOperator(CompoundOperator):
                 op.set_input_guide(guide)
 
     def __str__(self) -> str:
-        named_children = [
-            (name, f"{module.__class__.__name__}({module.description()})")
-            for name, module in self.named_children()
-        ]
-        return self._build_str(named_children=named_children)
+        def build_encoder_str():
+            multi_layer_encoder = next(self.children()).encoder.multi_layer_encoder
+            name = multi_layer_encoder.__class__.__name__
+            properties = multi_layer_encoder.properties()
+            named_children = ()
+            return self._build_str(
+                name=name, properties=properties, named_children=named_children
+            )
 
-    def description(self) -> str:
-        return self._description
+        def build_op_str(op):
+            properties = op.properties()
+            del properties["encoder"]
+            return op._build_str(properties=properties, named_children=())
+
+
+        properties = OrderedDict()
+        properties["encoder"] = build_encoder_str()
+        properties.update(self.properties())
+
+        named_children = [(name, build_op_str(op)) for name, op in self.named_children()]
+
+        return self._build_str(properties=properties, named_children=named_children)
 
 
 class MultiRegionOperator(CompoundOperator):

--- a/pystiche/ops/op.py
+++ b/pystiche/ops/op.py
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 
-class Operator(ABC, pystiche.Module):
+class Operator(pystiche.Module):
     def __init__(self, score_weight: float = 1.0) -> None:
         super().__init__()
         self.score_weight = score_weight

--- a/pystiche/ops/op.py
+++ b/pystiche/ops/op.py
@@ -3,7 +3,7 @@ from typing import Any, Union, Optional, Tuple, Dict
 from collections import OrderedDict
 import torch
 import pystiche
-from pystiche.misc import to_engstr
+from pystiche.misc import to_engstr, is_almost
 from pystiche.enc import Encoder
 
 __all__ = [
@@ -33,7 +33,7 @@ class Operator(pystiche.Module):
 
     def _properties(self) -> Dict[str, Any]:
         dct = OrderedDict()
-        if abs(self.score_weight - 1e0) > 1e-6:
+        if not is_almost(self.score_weight, 1e0):
             dct["score_weight"] = to_engstr(self.score_weight)
         return dct
 

--- a/pystiche/ops/regularization.py
+++ b/pystiche/ops/regularization.py
@@ -1,5 +1,6 @@
 import torch
 from .op import PixelRegularizationOperator
+from pystiche.misc import to_engstr
 from pystiche import functional as F
 
 __all__ = ["TotalVariationOperator", "ValueRangeOperator"]
@@ -16,10 +17,11 @@ class TotalVariationOperator(PixelRegularizationOperator):
     def calculate_score(self, input_repr: torch.Tensor) -> torch.Tensor:
         return F.total_variation_loss(input_repr, exponent=self.exponent)
 
-    # def _descriptions(self) -> Dict[str, Any]:
-    #     dct = super()._descriptions()
-    #     dct["Exponent"] = to_engstr(self.exponent)
-    #     return dct
+    def _properties(self):
+        dct = super()._properties()
+        if abs(self.exponent - 2.0) < 1e-6:
+            dct["exponent"] = to_engstr(self.exponent)
+        return dct
 
 
 class ValueRangeOperator(PixelRegularizationOperator):

--- a/pystiche/ops/regularization.py
+++ b/pystiche/ops/regularization.py
@@ -1,6 +1,6 @@
 import torch
 from .op import PixelRegularizationOperator
-from pystiche.misc import to_engstr
+from pystiche.misc import to_engstr, is_almost
 from pystiche import functional as F
 
 __all__ = ["TotalVariationOperator", "ValueRangeOperator"]
@@ -19,7 +19,7 @@ class TotalVariationOperator(PixelRegularizationOperator):
 
     def _properties(self):
         dct = super()._properties()
-        if abs(self.exponent - 2.0) < 1e-6:
+        if not is_almost(self.exponent, 2.0):
             dct["exponent"] = to_engstr(self.exponent)
         return dct
 

--- a/pystiche/pyramid/level.py
+++ b/pystiche/pyramid/level.py
@@ -1,16 +1,16 @@
 from typing import Optional
 import torch
-from pystiche.misc import verify_str_arg, build_obj_str
+from pystiche import Object
+from pystiche.misc import verify_str_arg
 from pystiche.image.transforms import FixedAspectRatioResize
 
 __all__ = ["PyramidLevel"]
 
 
-class PyramidLevel:
+class PyramidLevel(Object):
     def __init__(self, edge_size: int, num_steps: int, edge: str):
-
-        self.num_steps: int = num_steps
         self.edge_size = edge_size
+        self.num_steps: int = num_steps
         self.edge = verify_str_arg(edge, "edge", ("short", "long"))
 
     def _resize(
@@ -46,13 +46,9 @@ class PyramidLevel:
         for step in range(self.num_steps):
             yield step
 
-    def __str__(self):
-        name = self.__class__.__name__
-        description = ", ".join(
-            [
-                f"num_steps={self.num_steps}",
-                f"edge_size={self.edge_size}",
-                f"edge={self.edge}",
-            ]
-        )
-        return build_obj_str(name, description=description)
+    def _properties(self):
+        dct = super()._properties()
+        dct["edge_size"] = self.edge_size
+        dct["num_steps"] = self.num_steps
+        dct["edge"] = self.edge
+        return dct

--- a/pystiche/pyramid/level.py
+++ b/pystiche/pyramid/level.py
@@ -1,6 +1,6 @@
 from typing import Optional
 import torch
-from pystiche.misc import verify_str_arg
+from pystiche.misc import verify_str_arg, build_obj_str
 from pystiche.image.transforms import FixedAspectRatioResize
 
 __all__ = ["PyramidLevel"]
@@ -11,7 +11,6 @@ class PyramidLevel:
 
         self.num_steps: int = num_steps
         self.edge_size = edge_size
-
         self.edge = verify_str_arg(edge, "edge", ("short", "long"))
 
     def _resize(
@@ -47,8 +46,13 @@ class PyramidLevel:
         for step in range(self.num_steps):
             yield step
 
-    # def extra_str(self) -> str:
-    #     extras = ["num_steps={num_steps}", "edge_size={edge_size}", "edge={edge}"]
-    #     if self.interpolation_mode != "bilinear":
-    #         extras.append("interpolation_mode={interpolation_mode}")
-    #     return ", ".join(extras).format(**self.__dict__)
+    def __str__(self):
+        name = self.__class__.__name__
+        description = ", ".join(
+            [
+                f"num_steps={self.num_steps}",
+                f"edge_size={self.edge_size}",
+                f"edge={self.edge}",
+            ]
+        )
+        return build_obj_str(name, description=description)

--- a/pystiche/pyramid/pyramid.py
+++ b/pystiche/pyramid/pyramid.py
@@ -1,7 +1,7 @@
 from typing import Union, Optional, Sequence, Collection, Iterator
 import itertools
 import numpy as np
-from pystiche.misc import zip_equal
+from pystiche.misc import zip_equal, build_obj_str
 from pystiche.ops import Operator, ComparisonOperator, Guidance, ComparisonGuidance
 from .level import PyramidLevel
 from .storage import ImageStorage
@@ -75,6 +75,17 @@ class ImagePyramid:
             if isinstance(module, Operator):
                 yield module
 
+    def __str__(self):
+        name = self.__class__.__name__
+        if self.interpolation_mode != "bilinear":
+            description = f"interpolation_mode={self.interpolation_mode}"
+        else:
+            description = ""
+        named_children = [(str(idx), level) for idx, level in enumerate(self._levels)]
+        return build_obj_str(
+            name, description=description, named_children=named_children
+        )
+
 
 class OctaveImagePyramid(ImagePyramid):
     def __init__(
@@ -83,7 +94,7 @@ class OctaveImagePyramid(ImagePyramid):
         num_steps: Union[int, Sequence[int]],
         num_levels: Optional[int] = None,
         min_edge_size: int = 64,
-        **kwargs
+        **kwargs,
     ):
         if num_levels is None:
             num_levels = int(np.floor(np.log2(max_edge_size / min_edge_size))) + 1

--- a/pystiche/pyramid/pyramid.py
+++ b/pystiche/pyramid/pyramid.py
@@ -1,7 +1,8 @@
 from typing import Union, Optional, Sequence, Collection, Iterator
 import itertools
 import numpy as np
-from pystiche.misc import zip_equal, build_obj_str
+from pystiche import Object
+from pystiche.misc import zip_equal
 from pystiche.ops import Operator, ComparisonOperator, Guidance, ComparisonGuidance
 from .level import PyramidLevel
 from .storage import ImageStorage
@@ -10,7 +11,7 @@ from .storage import ImageStorage
 __all__ = ["ImagePyramid", "OctaveImagePyramid"]
 
 
-class ImagePyramid:
+class ImagePyramid(Object):
     def __init__(
         self,
         edge_sizes: Sequence[int],
@@ -75,16 +76,15 @@ class ImagePyramid:
             if isinstance(module, Operator):
                 yield module
 
-    def __str__(self):
-        name = self.__class__.__name__
+    def _properties(self):
+        dct = super()._properties()
         if self.interpolation_mode != "bilinear":
-            description = f"interpolation_mode={self.interpolation_mode}"
-        else:
-            description = ""
-        named_children = [(str(idx), level) for idx, level in enumerate(self._levels)]
-        return build_obj_str(
-            name, description=description, named_children=named_children
-        )
+            dct["interpolation_mode"] = self.interpolation_mode
+        return dct
+
+    def _named_children(self):
+        yield from super()._named_children()
+        yield from enumerate(self._levels)
 
 
 class OctaveImagePyramid(ImagePyramid):


### PR DESCRIPTION
This introduces `pystiche.Object` that implements a custom `__str__()` method. `pystiche.Module`, `pystiche.TensorStorage`, `pystiche.pyramid.ImagePyramid`, and `pystiche.pyramid.PyramidLevel` now inherit from it. To print  `pystiche.Module`s in the `torch` style use `print(repr(pystiche.Module))`

Additionally, the properties of the built-in operators are now once again included in the printing.