### PR TITLE
Clear encoding storage before restore in pyramid

### DIFF
--- a/pystiche/pyramid/pyramid.py
+++ b/pystiche/pyramid/pyramid.py
@@ -3,13 +3,7 @@ import itertools
 import numpy as np
 from pystiche import Object
 from pystiche.misc import zip_equal
-from pystiche.ops import (
-    Operator,
-    ComparisonOperator,
-    EncodingOperator,
-    Guidance,
-    ComparisonGuidance,
-)
+from pystiche.ops import Operator, ComparisonOperator, Guidance, ComparisonGuidance
 from .level import PyramidLevel
 from .storage import ImageStorage
 

--- a/pystiche/pyramid/pyramid.py
+++ b/pystiche/pyramid/pyramid.py
@@ -3,7 +3,13 @@ import itertools
 import numpy as np
 from pystiche import Object
 from pystiche.misc import zip_equal
-from pystiche.ops import Operator, ComparisonOperator, Guidance, ComparisonGuidance
+from pystiche.ops import (
+    Operator,
+    ComparisonOperator,
+    EncodingOperator,
+    Guidance,
+    ComparisonGuidance,
+)
 from .level import PyramidLevel
 from .storage import ImageStorage
 
@@ -49,6 +55,8 @@ class ImagePyramid(Object):
             try:
                 self._resize(level)
                 yield level
+            except Exception as exc:
+                raise exc
             finally:
                 image_storage.restore()
 


### PR DESCRIPTION
With this the encoding storage of all `MultiLayerEncoder`s is cleared before the original state of the `resize_targets` within an `ImagePyramid` is restored. Otherwise the storage might include the encodings of the `input_image`, which are then used for the target_image.

Furthermore, this raises the original `Exception` after the original state is restored opposed silently ignoring it.