### PR TITLE
Remove duplicate multiplication of score_weight

### DIFF
--- a/pystiche/ops/container.py
+++ b/pystiche/ops/container.py
@@ -18,7 +18,8 @@ class Container(Operator):
     def process_input_image(self, input_image: torch.Tensor) -> pystiche.LossDict:
         return pystiche.LossDict(
             [
-                (name, op(input_image) * self.score_weight)
+                # (name, op(input_image) * self.score_weight)
+                (name, op(input_image))
                 for name, op in self.named_children()
             ]
         )

--- a/pystiche/ops/container.py
+++ b/pystiche/ops/container.py
@@ -17,11 +17,7 @@ class Container(Operator):
 
     def process_input_image(self, input_image: torch.Tensor) -> pystiche.LossDict:
         return pystiche.LossDict(
-            [
-                # (name, op(input_image) * self.score_weight)
-                (name, op(input_image))
-                for name, op in self.named_children()
-            ]
+            [(name, op(input_image)) for name, op in self.named_children()]
         )
 
     def __getitem__(self, name):


### PR DESCRIPTION
This reverts #44, since the `score_weight` is already used in `Operator.forward()`, which calls `Operator.process_input_image()`. If left as is, the `score_weight` is multiplied twice.