### PR TITLE
Differentiate between single and batched images

### DIFF
--- a/pystiche/image/io.py
+++ b/pystiche/image/io.py
@@ -11,19 +11,23 @@ __all__ = ["read_image", "write_image", "show_image"]
 
 def read_image(
     file: str,
-    device=torch.device("cpu"),
+    device: Union[torch.device, str] = "cpu",
+    make_batched: bool = True,
     size: Optional[Union[int, Sequence[int]]] = None,
-    **kwargs: Any,
+    **resize_kwargs: Any,
 ) -> torch.Tensor:
-    image = import_from_pil(Image.open(file), device)
+    if isinstance(device, str):
+        device = torch.device(device)
+
+    image = import_from_pil(Image.open(file), device=device, make_batched=make_batched)
 
     if size is None:
         return image
 
     if is_image_size(size):
-        resize_transform = Resize(size, **kwargs)
+        resize_transform = Resize(size, **resize_kwargs)
     elif is_edge_size(size):
-        resize_transform = FixedAspectRatioResize(size, **kwargs)
+        resize_transform = FixedAspectRatioResize(size, **resize_kwargs)
     else:
         raise ValueError
     return resize_transform(image)

--- a/pystiche/image/io.py
+++ b/pystiche/image/io.py
@@ -1,7 +1,7 @@
 from typing import Any, Union, Optional, Sequence
 from PIL import Image
 import torch
-from .utils import is_image_size, is_edge_size
+from .utils import is_image_size, is_edge_size, verify_is_single_image
 from .transforms.functional import import_from_pil, export_to_pil
 from .transforms import Resize, FixedAspectRatioResize
 
@@ -13,7 +13,7 @@ def read_image(
     file: str,
     device=torch.device("cpu"),
     size: Optional[Union[int, Sequence[int]]] = None,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> torch.Tensor:
     image = import_from_pil(Image.open(file), device)
 
@@ -32,10 +32,12 @@ def read_image(
 def write_image(
     image: torch.Tensor, file: str, mode: Optional[str] = None, **kwargs: Any
 ):
+    verify_is_single_image(image)
     export_to_pil(image, mode=mode).save(file, **kwargs)
 
 
 def show_image(
     image: torch.Tensor, mode: Optional[str] = None, title: Optional[str] = None
 ):
+    verify_is_single_image(image)
     export_to_pil(image, mode=mode).show(title=title)

--- a/pystiche/image/transforms/functional/color.py
+++ b/pystiche/image/transforms/functional/color.py
@@ -1,5 +1,6 @@
 import torch
 import pystiche
+from pystiche.image.utils import force_batched_image
 from .misc import transform_channels_linearly
 
 __all__ = [
@@ -20,6 +21,7 @@ def rgb_to_grayscale(x: torch.Tensor) -> torch.Tensor:
     return transform_channels_linearly(x, transformation_matrix)
 
 
+@force_batched_image
 def grayscale_to_fakegrayscale(x: torch.Tensor) -> torch.Tensor:
     return x.repeat(1, 3, 1, 1)
 

--- a/pystiche/image/transforms/functional/misc.py
+++ b/pystiche/image/transforms/functional/misc.py
@@ -93,6 +93,7 @@ def transform_channels_linearly(x: torch.Tensor, matrix: torch.Tensor) -> torch.
     return transform_channels_affinely(x, matrix, bias=None)
 
 
+@force_batched_image
 def transform_channels_affinely(
     x: torch.Tensor, matrix: torch.Tensor, bias: Optional[torch.tensor] = None
 ) -> torch.Tensor:

--- a/pystiche/image/transforms/functional/misc.py
+++ b/pystiche/image/transforms/functional/misc.py
@@ -52,11 +52,12 @@ def export_to_pil(
         return _to_pil_image(image.detach().cpu().clamp(0.0, 1.0), mode)
 
     if is_batched_image(image):
-        batch_size = extract_batch_size(image)
+        batched_image = image
+        batch_size = extract_batch_size(batched_image)
         if batch_size == 1:
-            return fn(make_single_image(image))
+            return fn(make_single_image(batched_image))
         else:
-            return tuple([fn(single_image) for single_image in x])
+            return tuple([fn(single_image) for single_image in batched_image])
 
     return fn(image)
 

--- a/pystiche/image/transforms/functional/misc.py
+++ b/pystiche/image/transforms/functional/misc.py
@@ -76,8 +76,9 @@ def normalize(x: torch.Tensor, mean: Numeric, std: Numeric) -> torch.Tensor:
     return (x - mean) / std
 
 
+@force_batched_image
 def resize(
-    x: torch.Tensor, size: Sequence[int], interpolation_mode: str = "bilinear"
+    x: torch.FloatTensor, size: Sequence[int], interpolation_mode: str = "bilinear"
 ) -> torch.Tensor:
     return interpolate(
         x,

--- a/pystiche/image/transforms/functional/misc.py
+++ b/pystiche/image/transforms/functional/misc.py
@@ -6,11 +6,19 @@ from torchvision.transforms.functional import (
     to_tensor as _to_tensor,
     to_pil_image as _to_pil_image,
 )
-from pystiche.image.utils import apply_imagewise
+from pystiche.image.utils import (
+    verify_is_single_image,
+    is_single_image,
+    verify_is_image,
+    apply_imagewise,
+    extract_batch_size,
+)
 from pystiche.typing import Numeric
 from ._utils import get_align_corners
 
 __all__ = [
+    "add_batch_dim",
+    "remove_batch_dim",
     "import_from_pil",
     "export_to_pil",
     "normalize",
@@ -24,16 +32,29 @@ __all__ = [
 ]
 
 
+def add_batch_dim(x: torch.Tensor) -> torch.Tensor:
+    verify_is_single_image(x)
+    return x.unsqueeze(0)
+
+
+def remove_batch_dim(x: torch.Tensor) -> torch.Tensor:
+    batch_size = extract_batch_size(x)
+    if batch_size != 1:
+        msg = "ADDME"  # FIXME
+        raise RuntimeError(msg)
+    return x.squeeze(0)
+
+
 def import_from_pil(
     image: Image.Image,
     device: Union[torch.device, str] = "cpu",
-    add_batch_dim: bool = True,
+    make_batched: bool = True,
 ) -> torch.FloatTensor:
     if isinstance(device, str):
         device = torch.device(device)
     image = _to_tensor(image).to(device)
-    if add_batch_dim:
-        image = image.unsqueeze(0)
+    if make_batched:
+        image = add_batch_dim(image)
     return image
 
 

--- a/pystiche/image/transforms/functional/motif.py
+++ b/pystiche/image/transforms/functional/motif.py
@@ -4,7 +4,7 @@ import torch
 from torch.nn.functional import affine_grid, grid_sample
 from pystiche.typing import Numeric
 from pystiche.misc import verify_str_arg
-from pystiche.image.utils import extract_image_size
+from pystiche.image.utils import extract_image_size, force_batched_image
 from ._utils import get_align_corners
 
 __all__ = [
@@ -130,6 +130,7 @@ def create_affine_transformation_matrix(
     return torch.chain_matmul(*reversed(transformation_matrices))
 
 
+@force_batched_image
 def transform_motif_affinely(
     x: torch.Tensor,
     transformation_matrix: torch.Tensor,

--- a/pystiche/image/transforms/transforms.py
+++ b/pystiche/image/transforms/transforms.py
@@ -13,6 +13,8 @@ from . import functional as F
 __all__ = [
     "Transform",
     "Compose",
+    "AddBatchDim",
+    "RemoveBatchDim",
     "ImportFromPIL",
     "ExportToPIL",
     "FloatToUint8Range",
@@ -67,18 +69,28 @@ def _compose_transforms(*transforms: Tuple[Union[Transform, Compose], ...]) -> C
     return Compose(*itertools.chain(*map(unroll, transforms)))
 
 
+class AddBatchDim(Transform):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.add_batch_dim(x)
+
+
+class RemoveBatchDim(Transform):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.remove_batch_dim(x)
+
+
 class ImportFromPIL(Transform):
     def __init__(
-        self, device: Optional[torch.device] = None, add_batch_dim: bool = True
+        self, device: Optional[torch.device] = None, make_batched: bool = True
     ):
         super().__init__()
         if device is None:
             device = torch.device("cpu")
         self.device = device
-        self.add_batch_dim = add_batch_dim
+        self.add_batch_dim = make_batched
 
     def forward(self, x: Image.Image) -> torch.Tensor:
-        return F.import_from_pil(x, self.device, add_batch_dim=self.add_batch_dim)
+        return F.import_from_pil(x, self.device, make_batched=self.add_batch_dim)
 
 
 class ExportToPIL(Transform):

--- a/pystiche/image/transforms/transforms.py
+++ b/pystiche/image/transforms/transforms.py
@@ -68,14 +68,17 @@ def _compose_transforms(*transforms: Tuple[Union[Transform, Compose], ...]) -> C
 
 
 class ImportFromPIL(Transform):
-    def __init__(self, device: Optional[torch.device] = None):
+    def __init__(
+        self, device: Optional[torch.device] = None, add_batch_dim: bool = True
+    ):
         super().__init__()
         if device is None:
             device = torch.device("cpu")
         self.device = device
+        self.add_batch_dim = add_batch_dim
 
-    def forward(self, x: Image) -> torch.Tensor:
-        return F.import_from_pil(x, self.device)
+    def forward(self, x: Image.Image) -> torch.Tensor:
+        return F.import_from_pil(x, self.device, add_batch_dim=self.add_batch_dim)
 
 
 class ExportToPIL(Transform):
@@ -83,7 +86,7 @@ class ExportToPIL(Transform):
         super().__init__()
         self.mode: Optional[str] = mode
 
-    def forward(self, x: torch.Tensor) -> Image:
+    def forward(self, x: torch.Tensor) -> Union[Image.Image, Tuple[Image.Image, ...]]:
         return F.export_to_pil(x, mode=self.mode)
 
     def extra_repr(self) -> str:

--- a/pystiche/image/transforms/transforms.py
+++ b/pystiche/image/transforms/transforms.py
@@ -13,8 +13,6 @@ from . import functional as F
 __all__ = [
     "Transform",
     "Compose",
-    "AddBatchDim",
-    "RemoveBatchDim",
     "ImportFromPIL",
     "ExportToPIL",
     "FloatToUint8Range",
@@ -67,16 +65,6 @@ def _compose_transforms(*transforms: Tuple[Union[Transform, Compose], ...]) -> C
             raise RuntimeError
 
     return Compose(*itertools.chain(*map(unroll, transforms)))
-
-
-class AddBatchDim(Transform):
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return F.add_batch_dim(x)
-
-
-class RemoveBatchDim(Transform):
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return F.remove_batch_dim(x)
 
 
 class ImportFromPIL(Transform):

--- a/pystiche/image/utils.py
+++ b/pystiche/image/utils.py
@@ -3,9 +3,11 @@ import torch
 from pystiche.misc import verify_str_arg
 
 __all__ = [
-    "verify_is_image",
+    "verify_is_single_image",
     "is_single_image",
+    "verify_is_batched_image",
     "is_batched_image",
+    "verify_is_image",
     "is_image",
     "is_image_size",
     "is_edge_size",

--- a/pystiche/image/utils.py
+++ b/pystiche/image/utils.py
@@ -19,6 +19,7 @@ __all__ = [
     "extract_image_size",
     "extract_edge_size",
     "extract_aspect_ratio",
+    "apply_imagewise",
 ]
 
 

--- a/pystiche/image/utils.py
+++ b/pystiche/image/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, TypeVar, Union, Sequence, Tuple, Callable
+from typing import Any, Sequence, Tuple
 import torch
 from pystiche.misc import verify_str_arg
 
@@ -24,7 +24,6 @@ __all__ = [
     "force_image",
     "force_single_image",
     "force_batched_image",
-    "apply_imagewise",
 ]
 
 
@@ -229,20 +228,3 @@ def force_batched_image(fn):
         return x
 
     return wrapper
-
-
-T = TypeVar("T")
-
-
-def apply_imagewise(
-    fn: Callable[[torch.Tensor], T], x: torch.Tensor
-) -> Union[T, Tuple[T, ...]]:
-    verify_is_image(x)
-    if is_batched_image(x):
-        batch_size = extract_batch_size(x)
-        if batch_size == 1:
-            return fn(x.squeeze(0))
-        else:
-            return tuple([fn(single_image) for single_image in x])
-
-    return fn(x)

--- a/pystiche/image/utils.py
+++ b/pystiche/image/utils.py
@@ -12,6 +12,8 @@ __all__ = [
     "calculate_aspect_ratio",
     "image_to_edge_size",
     "edge_to_image_size",
+    "extract_batch_size",
+    "extract_num_channels",
     "extract_image_size",
     "extract_edge_size",
     "extract_aspect_ratio",
@@ -91,6 +93,18 @@ def edge_to_image_size(
         return edge_size, round(edge_size * aspect_ratio)
     else:
         return round(edge_size / aspect_ratio), edge_size
+
+
+def extract_batch_size(x: torch.Tensor) -> int:
+    verify_is_image(x)
+    if not is_batched_image(x):
+        raise RuntimeError("Cannot extract a batch_size from a single image (CxHxW)")
+    return x.size()[0]
+
+
+def extract_num_channels(x: torch.Tensor) -> int:
+    verify_is_image(x)
+    return x.size()[-3]
 
 
 def extract_image_size(x: torch.Tensor) -> Tuple[int, int]:

--- a/pystiche/image/utils.py
+++ b/pystiche/image/utils.py
@@ -166,3 +166,20 @@ def extract_edge_size(x: torch.Tensor, edge: str = "short") -> int:
 
 def extract_aspect_ratio(x: torch.Tensor) -> float:
     return calculate_aspect_ratio(extract_image_size(x))
+
+
+T = TypeVar("T")
+
+
+def apply_imagewise(
+    fn: Callable[[torch.Tensor], T], x: torch.Tensor
+) -> Union[T, Tuple[T, ...]]:
+    verify_is_image(x)
+    if is_batched_image(x):
+        batch_size = extract_batch_size(x)
+        if batch_size == 1:
+            return fn(x.squeeze(0))
+        else:
+            return tuple([fn(single_image) for single_image in x])
+
+    return fn(x)

--- a/pystiche/image/utils.py
+++ b/pystiche/image/utils.py
@@ -28,11 +28,11 @@ __all__ = [
 ]
 
 
-def _verify_image_type(x: torch.Tensor) -> None:
-    if not isinstance(x, torch.FloatTensor):
+def _verify_image_dtype(x: torch.Tensor) -> None:
+    if x.dtype != torch.float32:
         msg = (
-            f"pystiche uses torch.FloatTensor as native image type, but got input of "
-            f"type {type(x)} instead."
+            f"pystiche uses torch.float32 as native image dtype, but got input with "
+            f"dtype {x.dtype} instead."
         )
         raise TypeError(msg)
 
@@ -65,7 +65,7 @@ def _verify_image_dims(x: Any) -> None:
 
 
 def verify_is_single_image(x: torch.Tensor) -> None:
-    _verify_image_type(x)
+    _verify_image_dtype(x)
     _verify_single_image_dims(x)
 
 
@@ -79,7 +79,7 @@ def is_single_image(x: torch.Tensor) -> bool:
 
 
 def verify_is_batched_image(x: torch.Tensor) -> None:
-    _verify_image_type(x)
+    _verify_image_dtype(x)
     _verify_batched_image_dims(x)
 
 
@@ -93,7 +93,7 @@ def is_batched_image(x: torch.Tensor) -> bool:
 
 
 def verify_is_image(x: torch.Tensor) -> None:
-    _verify_image_type(x)
+    _verify_image_dtype(x)
     _verify_image_dims(x)
 
 

--- a/pystiche/image/utils.py
+++ b/pystiche/image/utils.py
@@ -3,6 +3,10 @@ import torch
 from pystiche.misc import verify_str_arg
 
 __all__ = [
+    "verify_is_image",
+    "is_single_image",
+    "is_batched_image",
+    "is_image",
     "is_image_size",
     "is_edge_size",
     "calculate_aspect_ratio",
@@ -12,6 +16,34 @@ __all__ = [
     "extract_edge_size",
     "extract_aspect_ratio",
 ]
+
+
+def verify_is_image(x: Any):
+    if not isinstance(x, torch.FloatTensor):
+        msg = (
+            f"pystiche uses torch.FloatTensor as native image type, but got input of "
+            f"type {type(x)} instead."
+        )
+        raise TypeError(msg)
+
+    if not x.dim() in (3, 4):
+        msg = (
+            f"pystiche uses CxHxW tensors for single and BxCxHxW tensors for batched "
+            f"images, but got tensor with {x.dim()} dimensions instead."
+        )
+        raise TypeError(msg)
+
+
+def is_single_image(x: Any) -> bool:
+    return isinstance(x, torch.FloatTensor) and x.dim() == 3
+
+
+def is_batched_image(x: Any) -> bool:
+    return isinstance(x, torch.FloatTensor) and x.dim() == 4
+
+
+def is_image(x: Any) -> bool:
+    return is_single_image(x) or is_batched_image(x)
 
 
 def is_image_size(x: Any) -> bool:
@@ -62,7 +94,8 @@ def edge_to_image_size(
 
 
 def extract_image_size(x: torch.Tensor) -> Tuple[int, int]:
-    return tuple(x.size()[2:4])
+    verify_is_image(x)
+    return tuple(x.size()[-2:])
 
 
 def extract_edge_size(x: torch.Tensor, edge: str = "short") -> int:

--- a/test/test_image_transforms.py
+++ b/test/test_image_transforms.py
@@ -4,10 +4,10 @@ import numpy as np
 import torch
 from pystiche.image import calculate_aspect_ratio, edge_to_image_size, transforms
 from pystiche.image.transforms import functional as F
-from utils import PysticheImageTestscae
+from utils import PysticheImageTestcase
 
 
-class Tester(PysticheImageTestscae, unittest.TestCase):
+class Tester(PysticheImageTestcase, unittest.TestCase):
     def assertTransformEqualsPIL(
         self,
         pystiche_transform,

--- a/test/test_image_transforms.py
+++ b/test/test_image_transforms.py
@@ -54,7 +54,7 @@ class Tester(PysticheImageTestcase, unittest.TestCase):
         )
 
     def test_single_image_pil_import(self):
-        import_transform = transforms.ImportFromPIL(add_batch_dim=False)
+        import_transform = transforms.ImportFromPIL(make_batched=False)
 
         actual = import_transform(self.load_image("PIL"))
         desired = self.load_image("pystiche").squeeze(0)

--- a/test/test_image_transforms.py
+++ b/test/test_image_transforms.py
@@ -74,87 +74,257 @@ class Tester(PysticheImageTestcase, unittest.TestCase):
         for actual in actuals:
             self.assertImagesAlmostEqual(actual, desired)
 
-    def test_grayscale_to_fakegrayscale(self):
-        def PILGrayscaleToFakegrayscale():
-            def transform(image):
-                assert image.mode == "L"
-                return image.convert("RGB")
+    def test_resize(self):
+        def PILResizeTransform(image_size):
+            size = image_size[::-1]
+            return lambda image: image.resize(size, resample=Image.BILINEAR)
 
-            return transform
-
+        image_size = (100, 100)
+        pystiche_transform = transforms.Resize(image_size)
+        pil_transform = PILResizeTransform(image_size)
         self.assertTransformEqualsPIL(
-            pystiche_transform=transforms.GrayscaleToFakegrayscale(),
-            pil_transform=PILGrayscaleToFakegrayscale(),
-            pil_image=self.load_image("PIL").convert("L"),
+            pystiche_transform=pystiche_transform,
+            pil_transform=pil_transform,
+            mean_abs_tolerance=3e-2,
         )
 
-    def test_rgb_to_fakegrayscale(self):
-        def PILRGBToFakegrayscale():
+    def test_fixed_aspect_ratio_resize(self):
+        def PILFixedAspectRatioResizeTransform(edge_size, edge):
             def transform(image):
-                assert image.mode == "RGB"
-                return image.convert("L").convert("RGB")
+                aspect_ratio = calculate_aspect_ratio(image.size[::-1])
+                image_size = edge_to_image_size(edge_size, aspect_ratio, edge)
+                size = image_size[::-1]
+                return image.resize(size, resample=Image.BILINEAR)
 
             return transform
 
-        self.assertTransformEqualsPIL(
-            pystiche_transform=transforms.RGBToFakegrayscale(),
-            pil_transform=PILRGBToFakegrayscale(),
-        )
+        edge_size = 100
+        for edge in ("short", "long", "vert", "horz"):
+            pystiche_transform = transforms.FixedAspectRatioResize(edge_size, edge=edge)
+            pil_transform = PILFixedAspectRatioResizeTransform(edge_size, edge=edge)
+            self.assertTransformEqualsPIL(
+                pystiche_transform=pystiche_transform,
+                pil_transform=pil_transform,
+                mean_abs_tolerance=3e-2,
+            )
 
-    def test_grayscale_to_binary(self):
-        def PILGrayscaleToBinary():
+    def test_rescale(self):
+        def PILRescaleTransform(factor):
             def transform(image):
-                assert image.mode == "L"
-                return image.convert("1", dither=0)
+                size = [round(edge_size * factor) for edge_size in image.size]
+                return image.resize(size, resample=Image.BILINEAR)
 
             return transform
 
+        factor = 1.0 / np.pi
+        pystiche_transform = transforms.Rescale(factor)
+        pil_transform = PILRescaleTransform(factor)
         self.assertTransformEqualsPIL(
-            pystiche_transform=transforms.GrayscaleToBinary(),
-            pil_transform=PILGrayscaleToBinary(),
-            pil_image=self.load_image("PIL").convert("L"),
-        )
-
-    def test_rgb_to_binary(self):
-        def PILRGBToBinary():
-            def transform(image):
-                assert image.mode == "RGB"
-                return image.convert("1", dither=0)
-
-            return transform
-
-        self.assertTransformEqualsPIL(
-            pystiche_transform=transforms.RGBToBinary(), pil_transform=PILRGBToBinary()
-        )
-
-    def test_rgb_to_yuv(self):
-        def PILRGBToYUV():
-            def transform(image):
-                assert image.mode == "RGB"
-                # fmt: off
-                matrix = (
-                     0.299,  0.587,  0.114, 0.0,
-                    -0.147, -0.289,  0.436, 0.0,
-                     0.615, -0.515, -0.100, 0.0
-                )
-                # fmt: on
-                return image.convert("RGB", matrix)
-
-            return transform
-
-        self.assertTransformEqualsPIL(
-            pystiche_transform=transforms.RGBToYUV(),
-            pil_transform=PILRGBToYUV(),
+            pystiche_transform=pystiche_transform,
+            pil_transform=pil_transform,
             mean_abs_tolerance=2e-2,
         )
 
-    def test_yuv_to_rgb(self):
-        def transform(image):
-            rgb_to_yuv = transforms.RGBToYUV()
-            yuv_to_rgb = transforms.YUVToRGB()
-            return yuv_to_rgb(rgb_to_yuv(image))
-
-        self.assertIdentityTransform(transform, self.load_image("pystiche"))
+    #
+    # def test_translate_motif(self):
+    #     def PILTranslateMotif(translation, inverse=False):
+    #         if inverse:
+    #             translation = [-val for val in translation]
+    #         translate = (translation[0], -translation[1])
+    #         return lambda image: image.rotate(
+    #             0.0, translate=translate, resample=Image.BILINEAR
+    #         )
+    #
+    #     translation = (100.0, 100.0)
+    #     pystiche_transform = transforms.TranslateMotif(translation)
+    #     pil_transform = PILTranslateMotif(translation)
+    #     self.assertTransformEqualsPIL(
+    #         pystiche_transform=pystiche_transform, pil_transform=pil_transform
+    #     )
+    #
+    #     inverse = True
+    #     pystiche_transform = transforms.TranslateMotif(translation, inverse=inverse)
+    #     pil_transform = PILTranslateMotif(translation, inverse=inverse)
+    #     self.assertTransformEqualsPIL(
+    #         pystiche_transform=pystiche_transform, pil_transform=pil_transform
+    #     )
+    #
+    # def test_rotate_motif(self):
+    #     pil_image = self.load_image("PIL")
+    #
+    #     def PILRotateMotif(angle, clockwise=False, center=None):
+    #         if clockwise:
+    #             angle *= -1.0
+    #         if center is not None:
+    #             center = (center[0], pil_image.height - center[1])
+    #         return lambda image: image.rotate(
+    #             angle, center=center, resample=Image.BILINEAR
+    #         )
+    #
+    #     angle = 30
+    #     pystiche_transform = transforms.RotateMotif(angle)
+    #     pil_transform = PILRotateMotif(angle)
+    #     self.assertTransformEqualsPIL(
+    #         pystiche_transform=pystiche_transform,
+    #         pil_transform=pil_transform,
+    #         pil_image=pil_image,
+    #     )
+    #
+    #     clockwise = True
+    #     pystiche_transform = transforms.RotateMotif(angle, clockwise=clockwise)
+    #     pil_transform = PILRotateMotif(angle, clockwise=clockwise)
+    #     self.assertTransformEqualsPIL(
+    #         pystiche_transform=pystiche_transform,
+    #         pil_transform=pil_transform,
+    #         pil_image=pil_image,
+    #     )
+    #
+    #     center = (0, 0)
+    #     pystiche_transform = transforms.RotateMotif(angle, center=center)
+    #     pil_transform = PILRotateMotif(angle, center=center)
+    #     self.assertTransformEqualsPIL(
+    #         pystiche_transform=pystiche_transform,
+    #         pil_transform=pil_transform,
+    #         pil_image=pil_image,
+    #     )
+    #
+    # # FIXME: rename
+    # def test_transform_motif_affinely_crop(self):
+    #     def PILRotateMotif(angle, canvas):
+    #         if canvas == "same":
+    #             expand = False
+    #         elif canvas == "full":
+    #             expand = True
+    #         else:
+    #             raise ValueError
+    #         return lambda image: image.rotate(
+    #             angle, expand=expand, resample=Image.BILINEAR
+    #         )
+    #
+    #     # The PIL transform calculates the output image size differently than pystiche
+    #     # so an off-by-one error might occur for different angles
+    #     angle = 45.0
+    #     canvas = "full"
+    #     pystiche_transform = transforms.RotateMotif(angle=angle, canvas=canvas)
+    #     pil_transform = PILRotateMotif(angle=angle, canvas=canvas)
+    #
+    #     pystiche_image = torch.ones(1, 1, 100, 100)
+    #     pil_image = transforms.ExportToPIL()(pystiche_image)
+    #
+    #     self.assertTransformEqualsPIL(
+    #         pystiche_transform=pystiche_transform,
+    #         pil_transform=pil_transform,
+    #         pystiche_image=pystiche_image,
+    #         pil_image=pil_image,
+    #     )
+    #
+    #     actual = pystiche_transform(pystiche_image)
+    #     desired = pil_transform(pil_image)
+    #     self.assertImagesAlmostEqual(actual, desired)
+    #
+    # # FIXME: rename
+    # def test_transform_motif_affinely(self):
+    #     pynst_image = torch.ones(1, 1, 100, 100)
+    #
+    #     angle = 45.0
+    #     canvas = "valid"
+    #     pynst_transform = transforms.RotateMotif(angle=angle, canvas=canvas)
+    #     self.assertRaises(RuntimeError, pynst_transform, pynst_image)
+    #
+    # def test_rgb_to_grayscale(self):
+    #     def PILRGBToGrayscale():
+    #         def transform(image):
+    #             assert image.mode == "RGB"
+    #             return image.convert("L")
+    #
+    #         return transform
+    #
+    #     self.assertTransformEqualsPIL(
+    #         pystiche_transform=transforms.RGBToGrayscale(),
+    #         pil_transform=PILRGBToGrayscale(),
+    #     )
+    #
+    # def test_grayscale_to_fakegrayscale(self):
+    #     def PILGrayscaleToFakegrayscale():
+    #         def transform(image):
+    #             assert image.mode == "L"
+    #             return image.convert("RGB")
+    #
+    #         return transform
+    #
+    #     self.assertTransformEqualsPIL(
+    #         pystiche_transform=transforms.GrayscaleToFakegrayscale(),
+    #         pil_transform=PILGrayscaleToFakegrayscale(),
+    #         pil_image=self.load_image("PIL").convert("L"),
+    #     )
+    #
+    # def test_rgb_to_fakegrayscale(self):
+    #     def PILRGBToFakegrayscale():
+    #         def transform(image):
+    #             assert image.mode == "RGB"
+    #             return image.convert("L").convert("RGB")
+    #
+    #         return transform
+    #
+    #     self.assertTransformEqualsPIL(
+    #         pystiche_transform=transforms.RGBToFakegrayscale(),
+    #         pil_transform=PILRGBToFakegrayscale(),
+    #     )
+    #
+    # def test_grayscale_to_binary(self):
+    #     def PILGrayscaleToBinary():
+    #         def transform(image):
+    #             assert image.mode == "L"
+    #             return image.convert("1", dither=0)
+    #
+    #         return transform
+    #
+    #     self.assertTransformEqualsPIL(
+    #         pystiche_transform=transforms.GrayscaleToBinary(),
+    #         pil_transform=PILGrayscaleToBinary(),
+    #         pil_image=self.load_image("PIL").convert("L"),
+    #     )
+    #
+    # def test_rgb_to_binary(self):
+    #     def PILRGBToBinary():
+    #         def transform(image):
+    #             assert image.mode == "RGB"
+    #             return image.convert("1", dither=0)
+    #
+    #         return transform
+    #
+    #     self.assertTransformEqualsPIL(
+    #         pystiche_transform=transforms.RGBToBinary(), pil_transform=PILRGBToBinary()
+    #     )
+    #
+    # def test_rgb_to_yuv(self):
+    #     def PILRGBToYUV():
+    #         def transform(image):
+    #             assert image.mode == "RGB"
+    #             # fmt: off
+    #             matrix = (
+    #                  0.299,  0.587,  0.114, 0.0,
+    #                 -0.147, -0.289,  0.436, 0.0,
+    #                  0.615, -0.515, -0.100, 0.0
+    #             )
+    #             # fmt: on
+    #             return image.convert("RGB", matrix)
+    #
+    #         return transform
+    #
+    #     self.assertTransformEqualsPIL(
+    #         pystiche_transform=transforms.RGBToYUV(),
+    #         pil_transform=PILRGBToYUV(),
+    #         mean_abs_tolerance=2e-2,
+    #     )
+    #
+    # def test_yuv_to_rgb(self):
+    #     def transform(image):
+    #         rgb_to_yuv = transforms.RGBToYUV()
+    #         yuv_to_rgb = transforms.YUVToRGB()
+    #         return yuv_to_rgb(rgb_to_yuv(image))
+    #
+    #     self.assertIdentityTransform(transform, self.load_image("pystiche"))
 
 
 if __name__ == "__main__":

--- a/test/test_image_transforms.py
+++ b/test/test_image_transforms.py
@@ -2,7 +2,15 @@ import unittest
 from PIL import Image
 import numpy as np
 import torch
-from pystiche.image import calculate_aspect_ratio, edge_to_image_size, transforms
+from pystiche.image import (
+    is_single_image,
+    is_batched_image,
+    calculate_aspect_ratio,
+    edge_to_image_size,
+    make_single_image,
+    make_batched_image,
+    transforms,
+)
 from pystiche.image.transforms import functional as F
 from utils import PysticheImageTestcase
 
@@ -16,19 +24,43 @@ class Tester(PysticheImageTestcase, unittest.TestCase):
         pil_image=None,
         mean_abs_tolerance=1e-2,
     ):
-        if pil_image is None and pystiche_image is None:
-            pil_image = self.load_image("PIL")
-            pystiche_image = self.load_image("pystiche")
-        elif pil_image is None:
-            pil_image = F.export_to_pil(pystiche_image)
-        elif pystiche_image is None:
-            pystiche_image = F.import_from_pil(pil_image, torch.device("cpu"))
+        def parse_images(pystiche_image, pil_image):
+            if pystiche_image is None and pil_image is None:
+                pystiche_image = self.load_image("pystiche")
+                pil_image = self.load_image("PIL")
+            elif pystiche_image is None:
+                pystiche_image = F.import_from_pil(pil_image)
+            elif pil_image is None:
+                pil_image = F.export_to_pil(pystiche_image)
 
-        actual = pystiche_transform(pystiche_image)
-        desired = pil_transform(pil_image)
-        self.assertImagesAlmostEqual(
-            actual, desired, mean_abs_tolerance=mean_abs_tolerance
-        )
+            return pystiche_image, pil_image
+
+        def get_single_and_batched_pystiche_images(pystiche_image):
+            if is_single_image(pystiche_image):
+                pystiche_single_image = pystiche_image
+                pystiche_batched_image = make_batched_image(pystiche_single_image)
+            else:
+                pystiche_batched_image = pystiche_image
+                pystiche_single_image = make_single_image(pystiche_batched_image)
+
+            return pystiche_single_image, pystiche_batched_image
+
+        def assert_transform_equality(pystiche_image, pil_image):
+            actual = pystiche_transform(pystiche_image)
+            desired = pil_transform(pil_image)
+            self.assertImagesAlmostEqual(
+                actual, desired, mean_abs_tolerance=mean_abs_tolerance
+            )
+
+        pystiche_image, pil_image = parse_images(pystiche_image, pil_image)
+
+        (
+            pystiche_single_image,
+            pystiche_batched_image,
+        ) = get_single_and_batched_pystiche_images(pystiche_image)
+
+        assert_transform_equality(pystiche_single_image, pil_image)
+        assert_transform_equality(pystiche_batched_image, pil_image)
 
     def assertIdentityTransform(self, transform, image, mean_abs_tolerance=1e-2):
         actual = image
@@ -304,7 +336,7 @@ class Tester(PysticheImageTestcase, unittest.TestCase):
                 matrix = (
                      0.299,  0.587,  0.114, 0.0,
                     -0.147, -0.289,  0.436, 0.0,
-                     0.615, -0.515, -0.100, 0.0
+                     0.615, -0.515, -0.100, 0.0,
                 )
                 # fmt: on
                 return image.convert("RGB", matrix)

--- a/test/test_image_transforms.py
+++ b/test/test_image_transforms.py
@@ -57,14 +57,14 @@ class Tester(PysticheImageTestcase, unittest.TestCase):
         import_transform = transforms.ImportFromPIL(make_batched=False)
 
         actual = import_transform(self.load_image("PIL"))
-        desired = self.load_image("pystiche").squeeze(0)
+        desired = self.load_single_image()
         self.assertImagesAlmostEqual(actual, desired)
 
     def test_multi_image_pil_export(self):
         batch_size = 2
         export_transform = transforms.ExportToPIL()
 
-        batched_image = self.load_image("pystiche").repeat(batch_size, 1, 1, 1)
+        batched_image = self.load_batched_image(batch_size)
         actuals = export_transform(batched_image)
         desired = self.load_image("PIL")
 

--- a/test/test_image_transforms.py
+++ b/test/test_image_transforms.py
@@ -125,206 +125,205 @@ class Tester(PysticheImageTestcase, unittest.TestCase):
             mean_abs_tolerance=2e-2,
         )
 
-    #
-    # def test_translate_motif(self):
-    #     def PILTranslateMotif(translation, inverse=False):
-    #         if inverse:
-    #             translation = [-val for val in translation]
-    #         translate = (translation[0], -translation[1])
-    #         return lambda image: image.rotate(
-    #             0.0, translate=translate, resample=Image.BILINEAR
-    #         )
-    #
-    #     translation = (100.0, 100.0)
-    #     pystiche_transform = transforms.TranslateMotif(translation)
-    #     pil_transform = PILTranslateMotif(translation)
-    #     self.assertTransformEqualsPIL(
-    #         pystiche_transform=pystiche_transform, pil_transform=pil_transform
-    #     )
-    #
-    #     inverse = True
-    #     pystiche_transform = transforms.TranslateMotif(translation, inverse=inverse)
-    #     pil_transform = PILTranslateMotif(translation, inverse=inverse)
-    #     self.assertTransformEqualsPIL(
-    #         pystiche_transform=pystiche_transform, pil_transform=pil_transform
-    #     )
-    #
-    # def test_rotate_motif(self):
-    #     pil_image = self.load_image("PIL")
-    #
-    #     def PILRotateMotif(angle, clockwise=False, center=None):
-    #         if clockwise:
-    #             angle *= -1.0
-    #         if center is not None:
-    #             center = (center[0], pil_image.height - center[1])
-    #         return lambda image: image.rotate(
-    #             angle, center=center, resample=Image.BILINEAR
-    #         )
-    #
-    #     angle = 30
-    #     pystiche_transform = transforms.RotateMotif(angle)
-    #     pil_transform = PILRotateMotif(angle)
-    #     self.assertTransformEqualsPIL(
-    #         pystiche_transform=pystiche_transform,
-    #         pil_transform=pil_transform,
-    #         pil_image=pil_image,
-    #     )
-    #
-    #     clockwise = True
-    #     pystiche_transform = transforms.RotateMotif(angle, clockwise=clockwise)
-    #     pil_transform = PILRotateMotif(angle, clockwise=clockwise)
-    #     self.assertTransformEqualsPIL(
-    #         pystiche_transform=pystiche_transform,
-    #         pil_transform=pil_transform,
-    #         pil_image=pil_image,
-    #     )
-    #
-    #     center = (0, 0)
-    #     pystiche_transform = transforms.RotateMotif(angle, center=center)
-    #     pil_transform = PILRotateMotif(angle, center=center)
-    #     self.assertTransformEqualsPIL(
-    #         pystiche_transform=pystiche_transform,
-    #         pil_transform=pil_transform,
-    #         pil_image=pil_image,
-    #     )
-    #
-    # # FIXME: rename
-    # def test_transform_motif_affinely_crop(self):
-    #     def PILRotateMotif(angle, canvas):
-    #         if canvas == "same":
-    #             expand = False
-    #         elif canvas == "full":
-    #             expand = True
-    #         else:
-    #             raise ValueError
-    #         return lambda image: image.rotate(
-    #             angle, expand=expand, resample=Image.BILINEAR
-    #         )
-    #
-    #     # The PIL transform calculates the output image size differently than pystiche
-    #     # so an off-by-one error might occur for different angles
-    #     angle = 45.0
-    #     canvas = "full"
-    #     pystiche_transform = transforms.RotateMotif(angle=angle, canvas=canvas)
-    #     pil_transform = PILRotateMotif(angle=angle, canvas=canvas)
-    #
-    #     pystiche_image = torch.ones(1, 1, 100, 100)
-    #     pil_image = transforms.ExportToPIL()(pystiche_image)
-    #
-    #     self.assertTransformEqualsPIL(
-    #         pystiche_transform=pystiche_transform,
-    #         pil_transform=pil_transform,
-    #         pystiche_image=pystiche_image,
-    #         pil_image=pil_image,
-    #     )
-    #
-    #     actual = pystiche_transform(pystiche_image)
-    #     desired = pil_transform(pil_image)
-    #     self.assertImagesAlmostEqual(actual, desired)
-    #
-    # # FIXME: rename
-    # def test_transform_motif_affinely(self):
-    #     pynst_image = torch.ones(1, 1, 100, 100)
-    #
-    #     angle = 45.0
-    #     canvas = "valid"
-    #     pynst_transform = transforms.RotateMotif(angle=angle, canvas=canvas)
-    #     self.assertRaises(RuntimeError, pynst_transform, pynst_image)
-    #
-    # def test_rgb_to_grayscale(self):
-    #     def PILRGBToGrayscale():
-    #         def transform(image):
-    #             assert image.mode == "RGB"
-    #             return image.convert("L")
-    #
-    #         return transform
-    #
-    #     self.assertTransformEqualsPIL(
-    #         pystiche_transform=transforms.RGBToGrayscale(),
-    #         pil_transform=PILRGBToGrayscale(),
-    #     )
-    #
-    # def test_grayscale_to_fakegrayscale(self):
-    #     def PILGrayscaleToFakegrayscale():
-    #         def transform(image):
-    #             assert image.mode == "L"
-    #             return image.convert("RGB")
-    #
-    #         return transform
-    #
-    #     self.assertTransformEqualsPIL(
-    #         pystiche_transform=transforms.GrayscaleToFakegrayscale(),
-    #         pil_transform=PILGrayscaleToFakegrayscale(),
-    #         pil_image=self.load_image("PIL").convert("L"),
-    #     )
-    #
-    # def test_rgb_to_fakegrayscale(self):
-    #     def PILRGBToFakegrayscale():
-    #         def transform(image):
-    #             assert image.mode == "RGB"
-    #             return image.convert("L").convert("RGB")
-    #
-    #         return transform
-    #
-    #     self.assertTransformEqualsPIL(
-    #         pystiche_transform=transforms.RGBToFakegrayscale(),
-    #         pil_transform=PILRGBToFakegrayscale(),
-    #     )
-    #
-    # def test_grayscale_to_binary(self):
-    #     def PILGrayscaleToBinary():
-    #         def transform(image):
-    #             assert image.mode == "L"
-    #             return image.convert("1", dither=0)
-    #
-    #         return transform
-    #
-    #     self.assertTransformEqualsPIL(
-    #         pystiche_transform=transforms.GrayscaleToBinary(),
-    #         pil_transform=PILGrayscaleToBinary(),
-    #         pil_image=self.load_image("PIL").convert("L"),
-    #     )
-    #
-    # def test_rgb_to_binary(self):
-    #     def PILRGBToBinary():
-    #         def transform(image):
-    #             assert image.mode == "RGB"
-    #             return image.convert("1", dither=0)
-    #
-    #         return transform
-    #
-    #     self.assertTransformEqualsPIL(
-    #         pystiche_transform=transforms.RGBToBinary(), pil_transform=PILRGBToBinary()
-    #     )
-    #
-    # def test_rgb_to_yuv(self):
-    #     def PILRGBToYUV():
-    #         def transform(image):
-    #             assert image.mode == "RGB"
-    #             # fmt: off
-    #             matrix = (
-    #                  0.299,  0.587,  0.114, 0.0,
-    #                 -0.147, -0.289,  0.436, 0.0,
-    #                  0.615, -0.515, -0.100, 0.0
-    #             )
-    #             # fmt: on
-    #             return image.convert("RGB", matrix)
-    #
-    #         return transform
-    #
-    #     self.assertTransformEqualsPIL(
-    #         pystiche_transform=transforms.RGBToYUV(),
-    #         pil_transform=PILRGBToYUV(),
-    #         mean_abs_tolerance=2e-2,
-    #     )
-    #
-    # def test_yuv_to_rgb(self):
-    #     def transform(image):
-    #         rgb_to_yuv = transforms.RGBToYUV()
-    #         yuv_to_rgb = transforms.YUVToRGB()
-    #         return yuv_to_rgb(rgb_to_yuv(image))
-    #
-    #     self.assertIdentityTransform(transform, self.load_image("pystiche"))
+    def test_translate_motif(self):
+        def PILTranslateMotif(translation, inverse=False):
+            if inverse:
+                translation = [-val for val in translation]
+            translate = (translation[0], -translation[1])
+            return lambda image: image.rotate(
+                0.0, translate=translate, resample=Image.BILINEAR
+            )
+
+        translation = (100.0, 100.0)
+        pystiche_transform = transforms.TranslateMotif(translation)
+        pil_transform = PILTranslateMotif(translation)
+        self.assertTransformEqualsPIL(
+            pystiche_transform=pystiche_transform, pil_transform=pil_transform
+        )
+
+        inverse = True
+        pystiche_transform = transforms.TranslateMotif(translation, inverse=inverse)
+        pil_transform = PILTranslateMotif(translation, inverse=inverse)
+        self.assertTransformEqualsPIL(
+            pystiche_transform=pystiche_transform, pil_transform=pil_transform
+        )
+
+    def test_rotate_motif(self):
+        pil_image = self.load_image("PIL")
+
+        def PILRotateMotif(angle, clockwise=False, center=None):
+            if clockwise:
+                angle *= -1.0
+            if center is not None:
+                center = (center[0], pil_image.height - center[1])
+            return lambda image: image.rotate(
+                angle, center=center, resample=Image.BILINEAR
+            )
+
+        angle = 30
+        pystiche_transform = transforms.RotateMotif(angle)
+        pil_transform = PILRotateMotif(angle)
+        self.assertTransformEqualsPIL(
+            pystiche_transform=pystiche_transform,
+            pil_transform=pil_transform,
+            pil_image=pil_image,
+        )
+
+        clockwise = True
+        pystiche_transform = transforms.RotateMotif(angle, clockwise=clockwise)
+        pil_transform = PILRotateMotif(angle, clockwise=clockwise)
+        self.assertTransformEqualsPIL(
+            pystiche_transform=pystiche_transform,
+            pil_transform=pil_transform,
+            pil_image=pil_image,
+        )
+
+        center = (0, 0)
+        pystiche_transform = transforms.RotateMotif(angle, center=center)
+        pil_transform = PILRotateMotif(angle, center=center)
+        self.assertTransformEqualsPIL(
+            pystiche_transform=pystiche_transform,
+            pil_transform=pil_transform,
+            pil_image=pil_image,
+        )
+
+    # FIXME: rename
+    def test_transform_motif_affinely_crop(self):
+        def PILRotateMotif(angle, canvas):
+            if canvas == "same":
+                expand = False
+            elif canvas == "full":
+                expand = True
+            else:
+                raise ValueError
+            return lambda image: image.rotate(
+                angle, expand=expand, resample=Image.BILINEAR
+            )
+
+        # The PIL transform calculates the output image size differently than pystiche
+        # so an off-by-one error might occur for different angles
+        angle = 45.0
+        canvas = "full"
+        pystiche_transform = transforms.RotateMotif(angle=angle, canvas=canvas)
+        pil_transform = PILRotateMotif(angle=angle, canvas=canvas)
+
+        pystiche_image = torch.ones(1, 1, 100, 100)
+        pil_image = transforms.ExportToPIL()(pystiche_image)
+
+        self.assertTransformEqualsPIL(
+            pystiche_transform=pystiche_transform,
+            pil_transform=pil_transform,
+            pystiche_image=pystiche_image,
+            pil_image=pil_image,
+        )
+
+        actual = pystiche_transform(pystiche_image)
+        desired = pil_transform(pil_image)
+        self.assertImagesAlmostEqual(actual, desired)
+
+    # FIXME: rename
+    def test_transform_motif_affinely(self):
+        pynst_image = torch.ones(1, 1, 100, 100)
+
+        angle = 45.0
+        canvas = "valid"
+        pynst_transform = transforms.RotateMotif(angle=angle, canvas=canvas)
+        self.assertRaises(RuntimeError, pynst_transform, pynst_image)
+
+    def test_rgb_to_grayscale(self):
+        def PILRGBToGrayscale():
+            def transform(image):
+                assert image.mode == "RGB"
+                return image.convert("L")
+
+            return transform
+
+        self.assertTransformEqualsPIL(
+            pystiche_transform=transforms.RGBToGrayscale(),
+            pil_transform=PILRGBToGrayscale(),
+        )
+
+    def test_grayscale_to_fakegrayscale(self):
+        def PILGrayscaleToFakegrayscale():
+            def transform(image):
+                assert image.mode == "L"
+                return image.convert("RGB")
+
+            return transform
+
+        self.assertTransformEqualsPIL(
+            pystiche_transform=transforms.GrayscaleToFakegrayscale(),
+            pil_transform=PILGrayscaleToFakegrayscale(),
+            pil_image=self.load_image("PIL").convert("L"),
+        )
+
+    def test_rgb_to_fakegrayscale(self):
+        def PILRGBToFakegrayscale():
+            def transform(image):
+                assert image.mode == "RGB"
+                return image.convert("L").convert("RGB")
+
+            return transform
+
+        self.assertTransformEqualsPIL(
+            pystiche_transform=transforms.RGBToFakegrayscale(),
+            pil_transform=PILRGBToFakegrayscale(),
+        )
+
+    def test_grayscale_to_binary(self):
+        def PILGrayscaleToBinary():
+            def transform(image):
+                assert image.mode == "L"
+                return image.convert("1", dither=0)
+
+            return transform
+
+        self.assertTransformEqualsPIL(
+            pystiche_transform=transforms.GrayscaleToBinary(),
+            pil_transform=PILGrayscaleToBinary(),
+            pil_image=self.load_image("PIL").convert("L"),
+        )
+
+    def test_rgb_to_binary(self):
+        def PILRGBToBinary():
+            def transform(image):
+                assert image.mode == "RGB"
+                return image.convert("1", dither=0)
+
+            return transform
+
+        self.assertTransformEqualsPIL(
+            pystiche_transform=transforms.RGBToBinary(), pil_transform=PILRGBToBinary()
+        )
+
+    def test_rgb_to_yuv(self):
+        def PILRGBToYUV():
+            def transform(image):
+                assert image.mode == "RGB"
+                # fmt: off
+                matrix = (
+                     0.299,  0.587,  0.114, 0.0,
+                    -0.147, -0.289,  0.436, 0.0,
+                     0.615, -0.515, -0.100, 0.0
+                )
+                # fmt: on
+                return image.convert("RGB", matrix)
+
+            return transform
+
+        self.assertTransformEqualsPIL(
+            pystiche_transform=transforms.RGBToYUV(),
+            pil_transform=PILRGBToYUV(),
+            mean_abs_tolerance=2e-2,
+        )
+
+    def test_yuv_to_rgb(self):
+        def transform(image):
+            rgb_to_yuv = transforms.RGBToYUV()
+            yuv_to_rgb = transforms.YUVToRGB()
+            return yuv_to_rgb(rgb_to_yuv(image))
+
+        self.assertIdentityTransform(transform, self.load_image("pystiche"))
 
 
 if __name__ == "__main__":

--- a/test/test_image_utils.py
+++ b/test/test_image_utils.py
@@ -4,6 +4,42 @@ from pystiche.image import utils
 
 
 class Tester(unittest.TestCase):
+    def test_verify_is_image(self):
+        single_image = torch.zeros(1, 1, 1)
+        utils.verify_is_image(single_image)
+        batched_image = single_image.unsqueeze(0)
+        utils.verify_is_image(batched_image)
+
+        for dtype in (torch.uint8, torch.int):
+            with self.assertRaises(TypeError):
+                image = torch.zeros(1, 1, 1, dtype=dtype)
+                utils.verify_is_image(image)
+
+        for dim in (2, 5):
+            with self.assertRaises(TypeError):
+                image = torch.tensor(*[0.0] * dim)
+                utils.verify_is_image(image)
+
+    def test_is_single_image(self):
+        single_image = torch.zeros(1, 1, 1)
+        self.assertTrue(utils.is_single_image(single_image))
+        self.assertFalse(utils.is_single_image(single_image.byte()))
+        self.assertFalse(utils.is_single_image(single_image.unsqueeze(0)))
+
+    def test_is_batched_image(self):
+        batched_image = torch.zeros(1, 1, 1, 1)
+        self.assertTrue(utils.is_batched_image(batched_image))
+        self.assertFalse(utils.is_batched_image(batched_image.byte()))
+        self.assertFalse(utils.is_batched_image(batched_image.squeeze(0)))
+
+    def test_is_image(self):
+        single_image = torch.zeros(1, 1, 1)
+        batched_image = single_image.unsqueeze(0)
+        self.assertTrue(utils.is_image(single_image))
+        self.assertTrue(utils.is_image(batched_image))
+        self.assertFalse(utils.is_image(single_image.byte()))
+        self.assertFalse(utils.is_image(batched_image.byte()))
+
     def test_is_image_size(self):
         image_size = [1, 1]
         self.assertTrue(utils.is_image_size(image_size))

--- a/test/test_image_utils.py
+++ b/test/test_image_utils.py
@@ -4,6 +4,46 @@ from pystiche.image import utils
 
 
 class Tester(unittest.TestCase):
+    def test_verify_is_single_image(self):
+        single_image = torch.zeros(1, 1, 1)
+        utils.verify_is_single_image(single_image)
+
+        for dtype in (torch.uint8, torch.int):
+            with self.assertRaises(TypeError):
+                image = single_image.clone().to(dtype)
+                utils.verify_is_single_image(image)
+
+        for dim in (2, 4):
+            with self.assertRaises(TypeError):
+                image = torch.tensor(*[0.0] * dim)
+                utils.verify_is_single_image(image)
+
+    def test_is_single_image(self):
+        single_image = torch.zeros(1, 1, 1)
+        self.assertTrue(utils.is_single_image(single_image))
+        self.assertFalse(utils.is_single_image(single_image.byte()))
+        self.assertFalse(utils.is_single_image(single_image.unsqueeze(0)))
+
+    def test_verify_is_batched_image(self):
+        batched_image = torch.zeros(1, 1, 1, 1)
+        utils.verify_is_batched_image(batched_image)
+
+        for dtype in (torch.uint8, torch.int):
+            with self.assertRaises(TypeError):
+                image = batched_image.clone().to(dtype)
+                utils.verify_is_batched_image(image)
+
+        for dim in (3, 5):
+            with self.assertRaises(TypeError):
+                image = torch.tensor(*[0.0] * dim)
+                utils.verify_is_batched_image(image)
+
+    def test_is_batched_image(self):
+        batched_image = torch.zeros(1, 1, 1, 1)
+        self.assertTrue(utils.is_batched_image(batched_image))
+        self.assertFalse(utils.is_batched_image(batched_image.byte()))
+        self.assertFalse(utils.is_batched_image(batched_image.squeeze(0)))
+
     def test_verify_is_image(self):
         single_image = torch.zeros(1, 1, 1)
         utils.verify_is_image(single_image)
@@ -19,18 +59,6 @@ class Tester(unittest.TestCase):
             with self.assertRaises(TypeError):
                 image = torch.tensor(*[0.0] * dim)
                 utils.verify_is_image(image)
-
-    def test_is_single_image(self):
-        single_image = torch.zeros(1, 1, 1)
-        self.assertTrue(utils.is_single_image(single_image))
-        self.assertFalse(utils.is_single_image(single_image.byte()))
-        self.assertFalse(utils.is_single_image(single_image.unsqueeze(0)))
-
-    def test_is_batched_image(self):
-        batched_image = torch.zeros(1, 1, 1, 1)
-        self.assertTrue(utils.is_batched_image(batched_image))
-        self.assertFalse(utils.is_batched_image(batched_image.byte()))
-        self.assertFalse(utils.is_batched_image(batched_image.squeeze(0)))
 
     def test_is_image(self):
         single_image = torch.zeros(1, 1, 1)
@@ -119,7 +147,7 @@ class Tester(unittest.TestCase):
         self.assertEqual(actual, desired)
 
         single_image = torch.zeros(1, 1, 1)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             utils.extract_batch_size(single_image)
 
     def test_extract_num_channels(self):

--- a/test/test_image_utils.py
+++ b/test/test_image_utils.py
@@ -110,6 +110,31 @@ class Tester(unittest.TestCase):
         desired = (round(edge_size * aspect_ratio), edge_size)
         self.assertTupleEqual(actual, desired)
 
+    def test_extract_batch_size(self):
+        batch_size = 3
+
+        batched_image = torch.zeros(batch_size, 1, 1, 1)
+        actual = utils.extract_batch_size(batched_image)
+        desired = batch_size
+        self.assertEqual(actual, desired)
+
+        single_image = torch.zeros(1, 1, 1)
+        with self.assertRaises(RuntimeError):
+            utils.extract_batch_size(single_image)
+
+    def test_extract_num_channels(self):
+        num_channels = 3
+
+        single_image = torch.zeros(num_channels, 1, 1)
+        actual = utils.extract_num_channels(single_image)
+        desired = num_channels
+        self.assertEqual(actual, desired)
+
+        batched_image = single_image.unsqueeze(0)
+        actual = utils.extract_num_channels(batched_image)
+        desired = num_channels
+        self.assertEqual(actual, desired)
+
     def test_extract_image_size(self):
         height = 2
         width = 3

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,4 +1,4 @@
-from typing import Type, Union, Optional
+from typing import Type, Optional
 import pyimagetest
 from os import path
 import numpy as np
@@ -8,16 +8,16 @@ from PIL import Image
 
 class PysticheImageBackend(pyimagetest.ImageBackend):
     @property
-    def native_image_type(self) -> Type[torch.FloatTensor]:
-        return torch.FloatTensor
+    def native_image_type(self) -> Type[torch.Tensor]:
+        return torch.Tensor
 
-    def import_image(self, file: str) -> torch.FloatTensor:
+    def import_image(self, file: str) -> torch.Tensor:
         pil_image = Image.open(file)
         np_image = np.array(pil_image, dtype=np.float32) / 255.0
         pystiche_image = torch.from_numpy(np_image).permute((2, 0, 1)).unsqueeze(0)
         return pystiche_image
 
-    def export_image(self, image: torch.FloatTensor) -> np.ndarray:
+    def export_image(self, image: torch.Tensor) -> np.ndarray:
         image = image.detach().cpu()
         if image.dim() == 4 and image.size()[0] == 1:
             image = image.squeeze(0)
@@ -39,7 +39,8 @@ class PysticheImageTestcase(pyimagetest.ImageTestcase):
         # The test image was downloaded from
         # http://www.r0k.us/graphics/kodak/kodim15.html
         # and is cleared for unrestricted usage
-        return path.join(path.dirname(__file__), "test_image.png")
+        here = path.abspath(path.dirname(__file__))
+        return path.join(here, "test_image.png")
 
     def load_batched_image(self, batch_size: int = 1, file: Optional[str] = None):
         return self.load_image("pystiche", file=file).repeat(batch_size, 1, 1, 1)

--- a/test/utils.py
+++ b/test/utils.py
@@ -18,7 +18,10 @@ class PysticheImageBackend(pyimagetest.ImageBackend):
         return pystiche_image
 
     def export_image(self, image: torch.FloatTensor) -> np.ndarray:
-        return image.detach().cpu().squeeze(0).permute((1, 2, 0)).numpy()
+        image = image.detach().cpu()
+        if image.dim() == 4 and image.size()[0] == 1:
+            image = image.squeeze(0)
+        return image.permute((1, 2, 0)).numpy()
 
 
 class PysticheImageTestcase(pyimagetest.ImageTestcase):
@@ -38,15 +41,8 @@ class PysticheImageTestcase(pyimagetest.ImageTestcase):
         # and is cleared for unrestricted usage
         return path.join(path.dirname(__file__), "test_image.png")
 
-    def load_image(
-        self,
-        backend: Union[pyimagetest.ImageBackend, str] = "pystiche",
-        file: Optional[str] = None,
-    ):
-        return super().load_image(backend, file=file)
-
     def load_batched_image(self, batch_size: int = 1, file: Optional[str] = None):
-        return self.load_image(file=file).repeat(batch_size, 1, 1, 1)
+        return self.load_image("pystiche", file=file).repeat(batch_size, 1, 1, 1)
 
     def load_single_image(self, file: Optional[str] = None):
         return self.load_batched_image(file=file).squeeze(0)

--- a/test/utils.py
+++ b/test/utils.py
@@ -37,3 +37,10 @@ class PysticheImageTestscae(pyimagetest.ImageTestcase):
         # http://www.r0k.us/graphics/kodak/kodim15.html
         # and is cleared for unrestricted usage
         return path.join(path.dirname(__file__), "test_image.png")
+
+    def load_image(
+        self,
+        backend: Union[pyimagetest.ImageBackend, str] = "pystiche",
+        file: Optional[str] = None,
+    ):
+        return super().load_image(backend, file=file)

--- a/test/utils.py
+++ b/test/utils.py
@@ -44,3 +44,9 @@ class PysticheImageTestcase(pyimagetest.ImageTestcase):
         file: Optional[str] = None,
     ):
         return super().load_image(backend, file=file)
+
+    def load_batched_image(self, batch_size: int = 1, file: Optional[str] = None):
+        return self.load_image(file=file).repeat(batch_size, 1, 1, 1)
+
+    def load_single_image(self, file: Optional[str] = None):
+        return self.load_batched_image(file=file).squeeze(0)

--- a/test/utils.py
+++ b/test/utils.py
@@ -4,7 +4,6 @@ from os import path
 import numpy as np
 import torch
 from PIL import Image
-from pystiche.image.transforms import ImportFromPIL
 
 
 class PysticheImageBackend(pyimagetest.ImageBackend):
@@ -13,9 +12,10 @@ class PysticheImageBackend(pyimagetest.ImageBackend):
         return torch.FloatTensor
 
     def import_image(self, file: str) -> torch.FloatTensor:
-        image = Image.open(file)
-        transform = ImportFromPIL()
-        return transform(image)
+        pil_image = Image.open(file)
+        np_image = np.array(pil_image, dtype=np.float32) / 255.0
+        pystiche_image = torch.from_numpy(np_image).permute((2, 1, 0)).unsqueeze(0)
+        return pystiche_image
 
     def export_image(self, image: torch.FloatTensor) -> np.ndarray:
         return image.detach().cpu().squeeze(0).permute((1, 2, 0)).numpy()

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Type, Union, Optional
 import pyimagetest
 from os import path
 import numpy as np
@@ -14,7 +14,7 @@ class PysticheImageBackend(pyimagetest.ImageBackend):
     def import_image(self, file: str) -> torch.FloatTensor:
         pil_image = Image.open(file)
         np_image = np.array(pil_image, dtype=np.float32) / 255.0
-        pystiche_image = torch.from_numpy(np_image).permute((2, 1, 0)).unsqueeze(0)
+        pystiche_image = torch.from_numpy(np_image).permute((2, 0, 1)).unsqueeze(0)
         return pystiche_image
 
     def export_image(self, image: torch.FloatTensor) -> np.ndarray:

--- a/test/utils.py
+++ b/test/utils.py
@@ -21,7 +21,7 @@ class PysticheImageBackend(pyimagetest.ImageBackend):
         return image.detach().cpu().squeeze(0).permute((1, 2, 0)).numpy()
 
 
-class PysticheImageTestscae(pyimagetest.ImageTestcase):
+class PysticheImageTestcase(pyimagetest.ImageTestcase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
With this PR `pystiche` can now handle single images `CxHxW` and as before batched images `BxCxHxW`. This was necessary since a `torch.utils.data.DataLoader` `torch.stack()`s images. If the image already has a batch dimension, `torch.stack()` creates erroneously a new, i.e. the fifth dimension. To prevent this `pystiche.image.read_image()` now has a `make_batched` parameter, which defaults to `True`.