### PR TITLE
Fix force_*image

### DIFF
--- a/pystiche/image/utils.py
+++ b/pystiche/image/utils.py
@@ -205,7 +205,7 @@ def force_single_image(fn):
 
         x = fn(x, *args, **kwargs)
 
-        if is_batched:
+        if is_batched and verify_is_image(x):
             x = make_batched_image(x)
 
         return x
@@ -222,7 +222,7 @@ def force_batched_image(fn):
 
         x = fn(x, *args, **kwargs)
 
-        if is_single:
+        if is_single and verify_is_image(x):
             x = make_single_image(x)
 
         return x

--- a/pystiche/image/utils.py
+++ b/pystiche/image/utils.py
@@ -205,7 +205,7 @@ def force_single_image(fn):
 
         x = fn(x, *args, **kwargs)
 
-        if is_batched and verify_is_image(x):
+        if is_batched and is_image(x):
             x = make_batched_image(x)
 
         return x
@@ -222,7 +222,7 @@ def force_batched_image(fn):
 
         x = fn(x, *args, **kwargs)
 
-        if is_single and verify_is_image(x):
+        if is_single and is_image(x):
             x = make_single_image(x)
 
         return x


### PR DESCRIPTION
This checks if the return value `is_image()` before attempting a transform back in the original state. Without this functions that return None (`write_image()`, `read_image()`) or return something else will raise an `RuntimeError`.