### PR TITLE
Generalize unroll functionality of LossDict

### DIFF
--- a/pystiche/core/_base.py
+++ b/pystiche/core/_base.py
@@ -90,9 +90,14 @@ class LossDict(OrderedDict):
     def __setitem__(self, name: str, loss: Union[torch.Tensor, "LossDict"]) -> None:
         if isinstance(loss, torch.Tensor):
             super().__setitem__(name, loss)
-        elif isinstance(loss, LossDict):
+            return
+        if isinstance(loss, LossDict):
             for child_name, child_loss in loss.items():
                 super().__setitem__(f"{name}.{child_name}", child_loss)
+            return
+
+        # FIXME
+        raise TypeError
 
     def aggregate(self, max_depth: int) -> Union[torch.Tensor, "LossDict"]:
         if max_depth == 0:

--- a/pystiche/core/_base.py
+++ b/pystiche/core/_base.py
@@ -94,10 +94,7 @@ class LossDict(OrderedDict):
             for child_name, child_loss in loss.items():
                 super().__setitem__(f"{name}.{child_name}", child_loss)
 
-        # FIXME
-        raise TypeError
-
-    def aggregate(self, max_depth: int) -> Union[float, "LossDict"]:
+    def aggregate(self, max_depth: int) -> Union[torch.Tensor, "LossDict"]:
         if max_depth == 0:
             return sum(self.values())
 
@@ -123,7 +120,7 @@ class LossDict(OrderedDict):
         return self.total().item()
 
     def __float__(self) -> float:
-        return self.item()
+        return float(self.item())
 
     def __mul__(self, other) -> "LossDict":
         other = float(other)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,0 +1,16 @@
+import unittest
+import torch
+import pystiche
+
+
+class Tester(unittest.TestCase):
+    def test_LossDict_float(self):
+        losses = [(str(i), torch.tensor(i)) for i in range(3)]
+        loss_dict = pystiche.LossDict(losses)
+
+        self.assertAlmostEqual(loss_dict.item(), 3.0)
+        self.assertAlmostEqual(loss_dict.item(), float(loss_dict))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The `LossDict` has the ability to _unroll_ other `LossDict`s if they are assigned. Right now this is only performed during `__init__()`. This path generalizes this functionality to `__setitem__()`.