### PR TITLE
Use requests for image download

### DIFF
--- a/pystiche/data/collections/image.py
+++ b/pystiche/data/collections/image.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional, Dict, Callable
 from os import path
-from urllib.request import urlretrieve
 from PIL import Image as PILImage
+import requests
 import torch
 import pystiche
 from pystiche.image import read_image
@@ -89,7 +89,8 @@ class DownloadableImage(Image):
         file = path.join(root, self.file)
 
         def download_and_transform(file: str):
-            urlretrieve(self.url, file)
+            with open(file, "wb") as fh:
+                fh.write(requests.get(self.url).content)
 
             if self.transform is not None:
                 self.transform(PILImage.open(file)).save(file)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, "pystiche", "__about__.py"), "r") as fh:
 with open(path.join(here, "README.md"), "r") as fh:
     long_description = fh.read()
 
-install_requires = ("numpy", "torch>=1.4.0", "pillow", "torchvision>=0.5.0")
+install_requires = ("torch>=1.4.0", "torchvision>=0.5.0", "pillow", "numpy", "requests")
 
 extras_require = {
     # FIXME: move to a released versions


### PR DESCRIPTION
While `urllib` is in the standard library, `urlretrieve.request.urlretrieve` often runs into `403 forbidden` errors. Using `requests` fixes this.

Example:

```python
from urllib.request import urlretrieve
import requests

url = "https://associateddesigns.com/sites/default/files/plan_images/main/craftsman_house_plan_tillamook_30-519-picart.jpg"

try:
    urlretrieve(url, "urlretrieve.jpg")
    print("urlretrieve() worked fine!")
except Exception as exc:
    print(f"urlretrieve() raised: {exc}")

try:
    with open("requests.jpg", "wb") as fh:
        fh.write(requests.get(url).content)
    print("requests() worked fine!")
except Exception as exc:
    print(f"requests() raised: {exc}")
```

Output:

```
urlretrieve() raised: HTTP Error 403: Forbidden
requests() worked fine!

```
