### PR TITLE
Add default images to demo scripts

### DIFF
--- a/demo/demo1.py
+++ b/demo/demo1.py
@@ -1,11 +1,11 @@
-from os import path
 from collections import OrderedDict
 import torch
 from torch import optim
-from pystiche.image import read_image, write_image
+from pystiche.image import write_image
 from pystiche.enc import vgg19_encoder
 from pystiche.ops import MSEEncodingOperator, GramOperator, MultiLayerEncodingOperator
 from pystiche.loss import MultiOperatorLoss
+from utils import demo_images
 
 # load the encoder used to create the feature maps for the NST
 multi_layer_encoder = vgg19_encoder()
@@ -38,16 +38,13 @@ criterion = MultiOperatorLoss(
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 criterion = criterion.to(device)
 
-# adapt these paths to fit your use case
-content_file = path.join("path", "to", "content", "image.jpg")
-style_file = path.join("path", "to", "style", "image.jpg")
-output_file = "pystiche_demo1.jpg"
 
 # load the content and style images and transfer them to the selected device
 # the images are resized, since the stylization is memory intensive
 size = 500
-content_image = read_image(content_file, device=device, size=size)
-style_image = read_image(style_file, device=device, size=size)
+images = demo_images()
+content_image = images["dancing"].read(size=size, device=device)
+style_image = images["picasso"].read(size=size, device=device)
 
 # set the target images for the content and style loss
 content_loss.set_target_image(content_image)
@@ -79,4 +76,4 @@ for step in range(num_steps):
     optimizer.step(closure)
 
 # save the stylized image
-write_image(input_image, output_file)
+write_image(input_image, "pystiche_demo1.jpg")

--- a/demo/demo2.py
+++ b/demo/demo2.py
@@ -1,12 +1,12 @@
-from os import path
 from collections import OrderedDict
 import torch
 from torch import optim
-from pystiche.image import read_image, write_image, extract_aspect_ratio
+from pystiche.image import write_image, extract_aspect_ratio
 from pystiche.enc import vgg19_encoder
 from pystiche.ops import MSEEncodingOperator, GramOperator, MultiLayerEncodingOperator
 from pystiche.loss import MultiOperatorLoss
 from pystiche.pyramid import ImagePyramid
+from utils import demo_images
 
 # load the encoder used to create the feature maps for the NST
 multi_layer_encoder = vgg19_encoder()
@@ -44,14 +44,10 @@ edge_sizes = (500, 700)
 num_steps = (500, 200)
 pyramid = ImagePyramid(edge_sizes, num_steps, resize_targets=(criterion,))
 
-# adapt these paths to fit your use case
-content_file = path.join("path", "to", "content", "image.jpg")
-style_file = path.join("path", "to", "style", "image.jpg")
-output_file = "pystiche_demo1.jpg"
-
 # load the content and style images and transfer them to the selected device
-content_image = read_image(content_file, device=device)
-style_image = read_image(style_file, device=device)
+images = demo_images()
+content_image = images["dancing"].read(device=device)
+style_image = images["picasso"].read(device=device)
 
 # resize the images, since the stylization is memory intensive
 resize = pyramid[-1].resize_image
@@ -69,6 +65,7 @@ input_image = content_image.clone()
 
 # extract the original aspect ratio to avoid size mismatch errors during resizing
 aspect_ratio = extract_aspect_ratio(input_image)
+
 
 # create optimizer that performs the stylization
 def get_optimizer(input_image):
@@ -96,4 +93,4 @@ for level in pyramid:
         optimizer.step(closure)
 
 # save the stylized image
-write_image(input_image, output_file)
+write_image(input_image, "pystiche_demo2.jpg")

--- a/demo/utils.py
+++ b/demo/utils.py
@@ -1,0 +1,17 @@
+from pystiche.data import DownloadableImage, DownloadableImageCollection
+
+__all__ = ["demo_images"]
+
+
+def demo_images():
+    images = {
+        "dancing": DownloadableImage(
+            "https://pytorch.org/tutorials/_static/img/neural-style/dancing.jpg",
+            md5="0a2df538901452d639170a2ed89815a4",
+        ),
+        "picasso": DownloadableImage(
+            "https://pytorch.org/tutorials/_static/img/neural-style/picasso.jpg",
+            md5="d1d60fc3f9d0b22d2d826c47934a37ea",
+        ),
+    }
+    return DownloadableImageCollection(images)


### PR DESCRIPTION
This adds the images from the [PyTorch tutorial](https://pytorch.org/tutorials/advanced/neural_style_tutorial.html#loading-the-images) as default images to the demo scripts.