### PR TITLE
Add default_transformer_epoch_optim_loop

### DIFF
--- a/pystiche/optim/log.py
+++ b/pystiche/optim/log.py
@@ -3,6 +3,8 @@ import contextlib
 import sys
 import logging
 import torch
+from torch.optim.optimizer import Optimizer
+from torch.optim.lr_scheduler import _LRScheduler as LRScheduler
 import pystiche
 from pystiche.pyramid.level import PyramidLevel
 from .meter import AverageMeter, LossMeter, ProgressMeter
@@ -167,3 +169,9 @@ def default_transformer_optim_log_fn(
             optim_logger.message(str(progress_meter))
 
     return log_fn
+
+
+def default_epoch_header_fn(
+    epoch: int, optimizer: Optimizer, lr_scheduler: Optional[LRScheduler]
+):
+    return f"Epoch {epoch}"

--- a/pystiche/optim/optim.py
+++ b/pystiche/optim/optim.py
@@ -1,4 +1,5 @@
 from typing import Union, Optional, Iterable, Tuple, Callable
+import warnings
 import time
 import torch
 from torch import nn, optim
@@ -143,12 +144,23 @@ def default_transformer_optim_loop(
     criterion: nn.Module,
     criterion_update_fn: Callable[[torch.Tensor, nn.ModuleDict], None],
     optimizer: Optional[Optimizer] = None,
+    get_optimizer: Optional[Callable[nn.Module], Optimizer] = None,
     quiet: bool = False,
     logger: Optional[OptimLogger] = None,
     log_fn: Optional[
         Callable[[int, Union[torch.Tensor, pystiche.LossDict], float, float], None]
     ] = None,
 ) -> nn.Module:
+    if get_optimizer is not None:
+        msg = (
+            "The parameter get_optimizer is deprecated since pystiche==0.4. "
+            "You can achieve the same functionality by passing "
+            "optimizer=get_optimizer(transformer). See "
+            "https://github.com/pmeier/pystiche/pull/96 for details."
+        )
+        warnings.warn(msg, UserWarning)
+        optimizer = get_optimizer(transformer)
+
     if optimizer is None:
         optimizer = default_transformer_optimizer(transformer)
 

--- a/pystiche/papers/johnson_alahi_li_2016/core.py
+++ b/pystiche/papers/johnson_alahi_li_2016/core.py
@@ -99,7 +99,7 @@ def johnson_alahi_li_2016_training(
         transformer,
         criterion,
         criterion_update_fn,
-        get_optimizer=get_optimizer,
+        optimizer=get_optimizer,
         quiet=quiet,
         logger=logger,
         log_fn=log_fn,


### PR DESCRIPTION
Based on [comment](https://github.com/pmeier/pystiche/pull/88#discussion_r391459374)

---

This adds a default optimization loop for transformers that need to be trained for more than one epoch. It simply calls `default_transformer_optim_loop()` within each epoch and optionally performs `lr_scheduler.step()` afterwards.

Since an `optimizer` wrapped by an `lr_scheduler` has to stay the same object between the epochs, the optional argument `get_optimizer` of `default_transformer_optim_loop()` is replaced by `optimizer`. This breaks BC. If `optimizer=None` is passed the same behavior as before is retained.

