### PR TITLE
fix (show|write)_image with scalar size

### DIFF
--- a/pystiche/image/io.py
+++ b/pystiche/image/io.py
@@ -68,7 +68,9 @@ def _pil_resize(
     if is_image_size(size):
         height, width = size
     elif is_edge_size(size):
-        height, width = edge_to_image_size(size, calculate_aspect_ratio(size))
+        height, width = edge_to_image_size(
+            size, calculate_aspect_ratio((image.height, image.size))
+        )
     else:
         raise RuntimeError
 


### PR DESCRIPTION
This fixes an error that was raised if `show_image()` or `write_image()` was called with an scalar `size`.