### PR TITLE
Add tests for LossDict

### DIFF
--- a/pystiche/core/_meta.py
+++ b/pystiche/core/_meta.py
@@ -5,6 +5,7 @@ from pystiche.typing import ConvModule, PoolModule
 
 __all__ = [
     "tensor_meta",
+    "is_scalar_tensor",
     "conv_module_meta",
     "pool_module_meta",
 ]
@@ -25,6 +26,10 @@ TensorMeta = Union[torch.device, torch.dtype]
 def tensor_meta(x: torch.Tensor, **kwargs: TensorMeta) -> Dict[str, TensorMeta]:
     attrs = ("dtype", "device")
     return _extract_meta_attrs(x, attrs, **kwargs)
+
+
+def is_scalar_tensor(x: torch.Tensor) -> bool:
+    return x.dim() == 0
 
 
 ConvModuleMeta = Union[int, Sequence[int]]

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -4,9 +4,116 @@ from utils import PysticheTestCase
 
 
 class TestCase(PysticheTestCase):
-    def test_LossDict_float(self):
-        losses = [(str(i), torch.tensor(i)) for i in range(3)]
-        loss_dict = pystiche.LossDict(losses)
+    def test_LossDict_setitem_Tensor(self):
+        name = "loss"
+        loss_dict = pystiche.LossDict()
 
-        self.assertAlmostEqual(loss_dict.item(), 3.0)
-        self.assertAlmostEqual(loss_dict.item(), float(loss_dict))
+        loss = torch.tensor(1.0)
+        loss_dict[name] = loss
+
+        actual = loss_dict[name]
+        desired = loss
+        self.assertTensorAlmostEqual(actual, desired)
+
+    def test_LossDict_setitem_non_scalar_Tensor(self):
+        name = "loss"
+        loss_dict = pystiche.LossDict()
+
+        with self.assertRaises(TypeError):
+            loss_dict[name] = torch.ones(1)
+
+    def test_LossDict_setitem_LossDict(self):
+        name = "loss"
+        loss_dict = pystiche.LossDict()
+        num_sub_losses = 3
+
+        loss = pystiche.LossDict(
+            [(str(idx), torch.tensor(idx)) for idx in range(num_sub_losses)]
+        )
+        loss_dict[name] = loss
+
+        for idx in range(num_sub_losses):
+            actual = loss_dict[f"{name}.{idx}"]
+            desired = loss[str(idx)]
+            self.assertTensorAlmostEqual(actual, desired)
+
+    def test_LossDict_setitem_other(self):
+        name = "loss"
+        loss_dict = pystiche.LossDict()
+
+        with self.assertRaises(TypeError):
+            loss_dict[name] = 1.0
+
+    def test_LossDict_total(self):
+        loss1 = torch.tensor(1.0)
+        loss2 = torch.tensor(2.0)
+
+        loss_dict = pystiche.LossDict((("loss1", loss1), ("loss2", loss2)))
+
+        actual = loss_dict.total()
+        desired = loss1 + loss2
+        self.assertTensorAlmostEqual(actual, desired)
+
+    def test_LossDict_backward(self):
+        losses = [
+            torch.tensor(val, dtype=torch.float, requires_grad=True) for val in range(3)
+        ]
+
+        def zero_grad():
+            for loss in losses:
+                loss.grad = None
+
+        def extract_grads():
+            return [loss.grad.clone() for loss in losses]
+
+        zero_grad()
+        loss_dict = pystiche.LossDict(
+            [(str(idx), loss) for idx, loss in enumerate(losses)]
+        )
+        loss_dict.backward()
+        actuals = extract_grads()
+
+        zero_grad()
+        total = sum(losses)
+        total.backward()
+        desireds = extract_grads()
+
+        for actual, desired in zip(actuals, desireds):
+            self.assertTensorAlmostEqual(actual, desired)
+
+    def test_LossDict_item(self):
+        losses = (1.0, 2.0)
+
+        loss_dict = pystiche.LossDict(
+            [(f"loss{idx}", torch.tensor(val)) for idx, val in enumerate(losses)]
+        )
+
+        actual = loss_dict.item()
+        desired = sum(losses)
+        self.assertAlmostEqual(actual, desired)
+
+    def test_LossDict_float(self):
+        loss_dict = pystiche.LossDict(
+            (("a", torch.tensor(0.0)), ("b", torch.tensor(1.0)))
+        )
+        self.assertAlmostEqual(float(loss_dict), loss_dict.item())
+
+    def test_LossDict_mul(self):
+        losses = (2.0, 3.0)
+        factor = 4.0
+
+        loss_dict = pystiche.LossDict(
+            [(f"loss{idx}", torch.tensor(val)) for idx, val in enumerate(losses)]
+        )
+        loss_dict = loss_dict * factor
+
+        for idx, loss in enumerate(losses):
+            actual = float(loss_dict[f"loss{idx}"])
+            desired = loss * factor
+            self.assertAlmostEqual(actual, desired)
+
+    def test_LossDict_str_smoke(self):
+        loss_dict = pystiche.LossDict(
+            (("a", torch.tensor(0.0)), ("b", torch.tensor(1.0)))
+        )
+        self.assertIsInstance(str(loss_dict), str)

--- a/test/utils.py
+++ b/test/utils.py
@@ -71,9 +71,17 @@ class PysticheTestCase(pyimagetest.ImageTestCase):
         desired = transform(image)
         self.assertImagesAlmostEqual(actual, desired, tolerance=tolerance)
 
-    def assertTensorAlmostEqual(self, actual, desired, **kwargs):
+    def assertTensorAlmostEqual(
+        self, actual, desired, check_dtype=True, check_device=True, **kwargs
+    ):
         def cast(x):
             return x.detach().cpu().numpy()
+
+        if check_dtype:
+            self.assertEqual(actual.dtype, desired.dtype)
+
+        if check_device:
+            self.assertEqual(actual.device, desired.device)
 
         np.testing.assert_allclose(cast(actual), cast(desired), **kwargs)
 


### PR DESCRIPTION
Additionally this adds `pystiche.is_scalar_tensor()` that, as the name implies, checks if a given `torch.Tensor` is scalar or not.