### PR TITLE
Add tests for pystiche.extract_patches*d

### DIFF
--- a/pystiche/core/_utils.py
+++ b/pystiche/core/_utils.py
@@ -17,7 +17,7 @@ def _extract_patchesnd(
     dims = range(2, x.dim())
     for dim, patch_size, stride in zip_equal(dims, patch_sizes, strides):
         x = x.unfold(dim, patch_size, stride)
-    x = x.permute(0, *dims, 1, *[dim + 2 for dim in dims]).contiguous()
+    x = x.permute(0, *dims, 1, *[dim + len(dims) for dim in dims]).contiguous()
     num_patches = prod(x.size()[: len(dims) + 1])
     return x.view(num_patches, num_channels, *patch_sizes)
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -270,3 +270,47 @@ class TestCase(PysticheTestCase):
         actual = pystiche.conv_module_meta(x, kernel_size=kernel_size)["kernel_size"]
         desired = kernel_size
         self.assertEqual(actual, desired)
+
+    def test_extract_patchesnd_num_patches(self):
+        batch_size = 2
+        size = 64
+        patch_size = 3
+        stride = 2
+
+        num_patches_per_dim = int((size - patch_size) // stride + 1)
+        torch.manual_seed(0)
+        for dims, extract_patches in enumerate(
+            (
+                pystiche.extract_patches1d,
+                pystiche.extract_patches2d,
+                pystiche.extract_patches3d,
+            ),
+            1,
+        ):
+            x = torch.rand(batch_size, 1, *[size] * dims)
+            patches = extract_patches(x, patch_size, stride=stride)
+
+            actual = patches.size()[0]
+            desired = batch_size * num_patches_per_dim ** dims
+            self.assertEqual(actual, desired)
+
+    def test_extract_patches1d(self):
+        batch_size = 2
+        length = 9
+        patch_size = 3
+        stride = 2
+
+        x = torch.arange(batch_size * length).view(batch_size, 1, -1)
+        patches = pystiche.extract_patches1d(x, patch_size, stride=stride)
+
+        actual = patches[0]
+        desired = x[0, :, :patch_size]
+        self.assertTensorAlmostEqual(actual, desired)
+
+        actual = patches[1]
+        desired = x[0, :, stride : (stride + patch_size)]
+        self.assertTensorAlmostEqual(actual, desired)
+
+        actual = patches[-1]
+        desired = x[-1, :, -patch_size:]
+        self.assertTensorAlmostEqual(actual, desired)


### PR DESCRIPTION
Additionally, a bug was fixed in `pystiche.core._utils._extract_patchesnd` that resulted in errors for `pystiche.extract_patches1d` and `pystiche.extract_patches2d`.