### PR TITLE
Refactor pystiche.Object

### DIFF
--- a/pystiche/core/_base.py
+++ b/pystiche/core/_base.py
@@ -17,14 +17,14 @@ from typing import (
 import torch
 from torch import nn
 
-from pystiche.misc import build_fmtstr, build_obj_str, format_dict
+from pystiche.misc import build_fmtstr, build_obj_str, format_dict, warn_deprecation
 
 from ._meta import is_scalar_tensor
 
-__all__ = ["Object", "TensorStorage", "LossDict", "TensorKey"]
+__all__ = ["ComplexObject", "TensorStorage", "LossDict", "TensorKey"]
 
 
-class Object(ABC):
+class ComplexObject(ABC):
     _STR_INDENT = 2
 
     def _properties(self) -> Dict[str, Any]:
@@ -76,9 +76,17 @@ class Object(ABC):
         return self._build_repr()
 
 
+class Object(ComplexObject):
+    def __init__(self, *args, **kwargs):
+        warn_deprecation(
+            "class", "Object", "0.4", info="It was renamed to ComplexObject."
+        )
+        super().__init__(*args, **kwargs)
+
+
 # TODO: can this be removed for now?
 #  If not it should subclass pystiche.Module and thus should be moved to ._modules
-class TensorStorage(nn.Module, Object):
+class TensorStorage(nn.Module, ComplexObject):
     def __init__(self, **attrs: Dict[str, Any]) -> None:
         super().__init__()
         for name, attr in attrs.items():

--- a/pystiche/core/_base.py
+++ b/pystiche/core/_base.py
@@ -50,7 +50,7 @@ class Object(ABC):
         yield from self._named_children()
         yield from self.extra_named_children()
 
-    def _build_str(
+    def _build_repr(
         self,
         name: Optional[str] = None,
         properties: Optional[Dict[str, str]] = None,
@@ -72,8 +72,8 @@ class Object(ABC):
             num_indent=self._STR_INDENT,
         )
 
-    def __str__(self) -> str:
-        return self._build_str()
+    def __repr__(self) -> str:
+        return self._build_repr()
 
 
 # TODO: can this be removed for now?

--- a/pystiche/core/_modules.py
+++ b/pystiche/core/_modules.py
@@ -41,6 +41,12 @@ class Module(nn.Module, Object):
     def forward(self, *args: Any, **kwargs: Any) -> Any:
         pass
 
+    def __repr__(self):
+        return Object.__repr__(self)
+
+    def torch_repr(self):
+        return nn.Module.__repr__(self)
+
     def extra_repr(self) -> str:
         return ", ".join([f"{key}={value}" for key, value in self.properties().items()])
 

--- a/pystiche/core/_modules.py
+++ b/pystiche/core/_modules.py
@@ -5,12 +5,12 @@ from typing import Any, Dict, Optional, Sequence
 import torch
 from torch import nn
 
-from ._base import Object
+from ._base import ComplexObject
 
 __all__ = ["Module", "SequentialModule"]
 
 
-class Module(nn.Module, Object):
+class Module(nn.Module, ComplexObject):
     def __init__(
         self,
         named_children: Optional[Dict[str, nn.Module]] = None,
@@ -42,7 +42,7 @@ class Module(nn.Module, Object):
         pass
 
     def __repr__(self):
-        return Object.__repr__(self)
+        return ComplexObject.__repr__(self)
 
     def torch_repr(self):
         return nn.Module.__repr__(self)

--- a/pystiche/data/collections/collection.py
+++ b/pystiche/data/collections/collection.py
@@ -7,7 +7,7 @@ from .image import DownloadableImage, Image
 __all__ = ["ImageCollection", "DownloadableImageCollection"]
 
 
-class ImageCollection(pystiche.Object):
+class ImageCollection(pystiche.ComplexObject):
     def __init__(
         self, images: Dict[str, Image], root: Optional[str] = None,
     ):

--- a/pystiche/data/collections/image.py
+++ b/pystiche/data/collections/image.py
@@ -14,7 +14,7 @@ from pystiche.image import read_image
 __all__ = ["Image", "DownloadableImage"]
 
 
-class Image(pystiche.Object):
+class Image(pystiche.ComplexObject):
     def __init__(
         self,
         file: str,

--- a/pystiche/enc/multi_layer_encoder.py
+++ b/pystiche/enc/multi_layer_encoder.py
@@ -150,7 +150,7 @@ class SingleLayerEncoder(Encoder):
     def propagate_guide(self, guide: torch.Tensor) -> torch.Tensor:
         return self.multi_layer_encoder.propagate_guide(guide, layers=(self.layer,))[0]
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         name = self.multi_layer_encoder.__class__.__name__
         properties = OrderedDict()
         properties["layer"] = self.layer

--- a/pystiche/enc/multi_layer_encoder.py
+++ b/pystiche/enc/multi_layer_encoder.py
@@ -156,6 +156,6 @@ class SingleLayerEncoder(Encoder):
         properties["layer"] = self.layer
         properties.update(self.multi_layer_encoder.properties())
         named_children = ()
-        return self._build_str(
+        return self._build_repr(
             name=name, properties=properties, named_children=named_children
         )

--- a/pystiche/ops/container.py
+++ b/pystiche/ops/container.py
@@ -100,14 +100,14 @@ class MultiLayerEncodingOperator(SameOperatorContainer):
             name = multi_layer_encoder.__class__.__name__
             properties = multi_layer_encoder.properties()
             named_children = ()
-            return self._build_str(
+            return self._build_repr(
                 name=name, properties=properties, named_children=named_children
             )
 
         def build_op_str(op):
             properties = op.properties()
             del properties["encoder"]
-            return op._build_str(properties=properties, named_children=())
+            return op._build_repr(properties=properties, named_children=())
 
         properties = OrderedDict()
         properties["encoder"] = build_encoder_str()
@@ -117,7 +117,7 @@ class MultiLayerEncodingOperator(SameOperatorContainer):
             (name, build_op_str(op)) for name, op in self.named_children()
         ]
 
-        return self._build_str(properties=properties, named_children=named_children)
+        return self._build_repr(properties=properties, named_children=named_children)
 
 
 class MultiRegionOperator(SameOperatorContainer):

--- a/pystiche/ops/container.py
+++ b/pystiche/ops/container.py
@@ -94,8 +94,8 @@ class MultiLayerEncodingOperator(SameOperatorContainer):
             if isinstance(op, Guidance):
                 op.set_input_guide(guide)
 
-    def __str__(self) -> str:
-        def build_encoder_str():
+    def __repr__(self) -> str:
+        def build_encoder_repr():
             multi_layer_encoder = next(self.children()).encoder.multi_layer_encoder
             name = multi_layer_encoder.__class__.__name__
             properties = multi_layer_encoder.properties()
@@ -104,17 +104,17 @@ class MultiLayerEncodingOperator(SameOperatorContainer):
                 name=name, properties=properties, named_children=named_children
             )
 
-        def build_op_str(op):
+        def build_op_repr(op):
             properties = op.properties()
             del properties["encoder"]
             return op._build_repr(properties=properties, named_children=())
 
         properties = OrderedDict()
-        properties["encoder"] = build_encoder_str()
+        properties["encoder"] = build_encoder_repr()
         properties.update(self.properties())
 
         named_children = [
-            (name, build_op_str(op)) for name, op in self.named_children()
+            (name, build_op_repr(op)) for name, op in self.named_children()
         ]
 
         return self._build_repr(properties=properties, named_children=named_children)

--- a/pystiche/ops/op.py
+++ b/pystiche/ops/op.py
@@ -117,7 +117,7 @@ class EncodingRegularizationOperator(EncodingOperator, RegularizationOperator):
         return dct
 
     def __str__(self) -> str:
-        return self._build_str(named_children=())
+        return self._build_repr(named_children=())
 
 
 class PixelComparisonOperator(PixelOperator, ComparisonOperator):
@@ -242,4 +242,4 @@ class EncodingComparisonOperator(EncodingOperator, ComparisonOperator):
         return dct
 
     def __str__(self) -> str:
-        return self._build_str(named_children=())
+        return self._build_repr(named_children=())

--- a/pystiche/ops/op.py
+++ b/pystiche/ops/op.py
@@ -116,7 +116,7 @@ class EncodingRegularizationOperator(EncodingOperator, RegularizationOperator):
         dct["encoder"] = self.encoder
         return dct
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return self._build_repr(named_children=())
 
 
@@ -241,5 +241,5 @@ class EncodingComparisonOperator(EncodingOperator, ComparisonOperator):
         dct["encoder"] = self.encoder
         return dct
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return self._build_repr(named_children=())

--- a/pystiche/pyramid/level.py
+++ b/pystiche/pyramid/level.py
@@ -2,14 +2,14 @@ from typing import Optional
 
 import torch
 
-from pystiche import Object
+from pystiche import ComplexObject
 from pystiche.image.transforms.functional import resize
 from pystiche.misc import verify_str_arg
 
 __all__ = ["PyramidLevel"]
 
 
-class PyramidLevel(Object):
+class PyramidLevel(ComplexObject):
     def __init__(self, edge_size: int, num_steps: int, edge: str):
         self.edge_size = edge_size
         self.num_steps: int = num_steps

--- a/pystiche/pyramid/pyramid.py
+++ b/pystiche/pyramid/pyramid.py
@@ -3,7 +3,7 @@ from typing import Collection, Iterator, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
-from pystiche import Object
+from pystiche import ComplexObject
 from pystiche.misc import zip_equal
 from pystiche.ops import ComparisonGuidance, ComparisonOperator, Guidance, Operator
 
@@ -13,7 +13,7 @@ from .storage import ImageStorage
 __all__ = ["ImagePyramid", "OctaveImagePyramid"]
 
 
-class ImagePyramid(Object):
+class ImagePyramid(ComplexObject):
     def __init__(
         self,
         edge_sizes: Sequence[int],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -493,13 +493,21 @@ class TestModules(PysticheTestCase):
         with self.assertRaises(RuntimeError):
             TestModule(named_children=named_children, indexed_children=indexed_children)
 
-    def test_Module_extra_repr_smoke(self):
+    def test_Module_repr_smoke(self):
         class TestModule(pystiche.Module):
             def forward(self):
                 pass
 
         test_module = TestModule()
-        self.assertIsInstance(test_module.extra_repr(), str)
+        self.assertIsInstance(repr(test_module), str)
+
+    def test_Module_torch_repr_smoke(self):
+        class TestModule(pystiche.Module):
+            def forward(self):
+                pass
+
+        test_module = TestModule()
+        self.assertIsInstance(test_module.torch_repr(), str)
 
     def test_SequentialModule(self):
         modules = (nn.Conv2d(3, 3, 3), nn.ReLU())

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,6 +10,7 @@ import torch
 from torch import nn
 
 import pystiche
+from pystiche.misc import build_obj_str
 from utils import PysticheTestCase, skip_if_cuda_not_available
 
 
@@ -21,7 +22,7 @@ class TestBase(PysticheTestCase):
         test_object = TestObject()
         self.assertIsInstance(str(test_object), str)
 
-    def test_Object_str(self):
+    def test_Object_repr(self):
         _properties = OrderedDict((("a", 1),))
         extra_properties = OrderedDict((("b", 2),))
         _named_children = (("c", 3),)
@@ -51,8 +52,8 @@ class TestBase(PysticheTestCase):
         )
         named_children = tuple(itertools.chain(_named_children, extra_named_children))
 
-        actual = str(test_object)
-        desired = test_object._build_str(
+        actual = repr(test_object)
+        desired = build_obj_str(
             name="TestObject", properties=properties, named_children=named_children
         )
         self.assertEqual(actual, desired)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,20 +15,20 @@ from utils import PysticheTestCase, skip_if_cuda_not_available
 
 
 class TestBase(PysticheTestCase):
-    def test_Object_repr_smoke(self):
-        class TestObject(pystiche.Object):
+    def test_ComplexObject_repr_smoke(self):
+        class TestObject(pystiche.ComplexObject):
             pass
 
         test_object = TestObject()
         self.assertIsInstance(repr(test_object), str)
 
-    def test_Object_repr(self):
+    def test_ComplexObject_repr(self):
         _properties = OrderedDict((("a", 1),))
         extra_properties = OrderedDict((("b", 2),))
         _named_children = (("c", 3),)
         extra_named_children = (("d", 4),)
 
-        class TestObject(pystiche.Object):
+        class TestObject(pystiche.ComplexObject):
             def _properties(self):
                 return _properties
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,12 +15,12 @@ from utils import PysticheTestCase, skip_if_cuda_not_available
 
 
 class TestBase(PysticheTestCase):
-    def test_Object_str_smoke(self):
+    def test_Object_repr_smoke(self):
         class TestObject(pystiche.Object):
             pass
 
         test_object = TestObject()
-        self.assertIsInstance(str(test_object), str)
+        self.assertIsInstance(repr(test_object), str)
 
     def test_Object_repr(self):
         _properties = OrderedDict((("a", 1),))
@@ -192,11 +192,11 @@ class TestBase(PysticheTestCase):
             desired = loss * factor
             self.assertAlmostEqual(actual, desired)
 
-    def test_LossDict_str_smoke(self):
+    def test_LossDict_repr_smoke(self):
         loss_dict = pystiche.LossDict(
             (("a", torch.tensor(0.0)), ("b", torch.tensor(1.0)))
         )
-        self.assertIsInstance(str(loss_dict), str)
+        self.assertIsInstance(repr(loss_dict), str)
 
     def test_TensorKey_eq(self):
         x = torch.tensor((0.0, 0.5, 1.0))

--- a/tests/test_data_collections.py
+++ b/tests/test_data_collections.py
@@ -26,11 +26,11 @@ class TestCollection(PysticheTestCase):
         desired = images
         self.assertDictEqual(actual, desired)
 
-    def test_ImageCollection_str_smoke(self):
+    def test_ImageCollection_repr_smoke(self):
         images = {str(idx): data.Image(str(idx)) for idx in range(3)}
         collection = data.ImageCollection(images)
 
-        self.assertIsInstance(str(collection), str)
+        self.assertIsInstance(repr(collection), str)
 
     def test_DownloadableImageCollection(self):
         with get_tmp_dir() as root:
@@ -52,9 +52,9 @@ class TestImage(PysticheTestCase):
         desired = self.load_image()
         self.assertImagesAlmostEqual(actual, desired)
 
-    def test_Image_str_smoke(self):
+    def test_Image_repr_smoke(self):
         image = data.Image("image")
-        self.assertIsInstance(str(image), str)
+        self.assertIsInstance(repr(image), str)
 
     def test_DownloadableImage_generate_file(self):
         url = TEST_IMAGE_URL
@@ -137,6 +137,6 @@ class TestImage(PysticheTestCase):
             desired = self.load_image()
             self.assertImagesAlmostEqual(actual, desired)
 
-    def test_DownloadableImage_str_smoke(self):
+    def test_DownloadableImage_repr_smoke(self):
         image = data.DownloadableImage(TEST_IMAGE_URL)
-        self.assertIsInstance(str(image), str)
+        self.assertIsInstance(repr(image), str)


### PR DESCRIPTION
This

- renames `pystiche.Object` to `pystiche.ComplexObject` to better reflect the purpose of this class
- changes the custom representation from `__str__` to `__repr__`
    -  the original `__repr__` of a `pystiche.Module` can be still accessed by `pystiche.Module.torch_repr()`