### PR TITLE
Remove option to construct subclasses of pystiche.Module with dicts

### DIFF
--- a/pystiche/core/_modules.py
+++ b/pystiche/core/_modules.py
@@ -1,9 +1,10 @@
 from abc import abstractmethod
-from collections import OrderedDict
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Optional, Sequence, Tuple
 
 import torch
 from torch import nn
+
+from pystiche.misc import warn_deprecation
 
 from ._base import ComplexObject
 
@@ -13,7 +14,7 @@ __all__ = ["Module", "SequentialModule"]
 class Module(nn.Module, ComplexObject):
     def __init__(
         self,
-        named_children: Optional[Dict[str, nn.Module]] = None,
+        named_children: Optional[Sequence[Tuple[str, nn.Module]]] = None,
         indexed_children: Optional[Sequence[nn.Module]] = None,
     ):
         super().__init__()
@@ -28,13 +29,21 @@ class Module(nn.Module, ComplexObject):
         elif indexed_children is not None:
             self.add_indexed_modules(indexed_children)
 
-    def add_named_modules(self, modules: Dict[str, nn.Module]) -> None:
-        for name, module in modules.items():
+    def add_named_modules(self, modules: Sequence[Tuple[str, nn.Module]]) -> None:
+        if isinstance(modules, dict):
+            warn_deprecation(
+                "bla",
+                "blub",
+                "0.4",
+                info="To achieve the same behavior you can pass tuple(modules.items())",
+            )
+            modules = tuple(modules.items())
+        for name, module in modules:
             self.add_module(name, module)
 
     def add_indexed_modules(self, modules: Sequence[nn.Module]) -> None:
         self.add_named_modules(
-            OrderedDict([(str(idx), module) for idx, module in enumerate(modules)])
+            [(str(idx), module) for idx, module in enumerate(modules)]
         )
 
     @abstractmethod

--- a/pystiche/core/_modules.py
+++ b/pystiche/core/_modules.py
@@ -32,8 +32,8 @@ class Module(nn.Module, ComplexObject):
     def add_named_modules(self, modules: Sequence[Tuple[str, nn.Module]]) -> None:
         if isinstance(modules, dict):
             warn_deprecation(
-                "bla",
-                "blub",
+                "parameter named_modules as ",
+                "dict",
                 "0.4",
                 info="To achieve the same behavior you can pass tuple(modules.items())",
             )

--- a/pystiche/enc/models/alexnet.py
+++ b/pystiche/enc/models/alexnet.py
@@ -30,9 +30,9 @@ class MultiLayerAlexNetEncoder(MultiLayerEncoder):
         base_model.load_state_dict(state_dict)
         model = base_model.features
 
-        modules = OrderedDict()
+        modules = []
         if self.preprocessing:
-            modules["preprocessing"] = get_preprocessor(self.weights)
+            modules.append(("preprocessing", get_preprocessor(self.weights)))
         block = 1
         for module in model.children():
             if isinstance(module, nn.Conv2d):
@@ -50,7 +50,7 @@ class MultiLayerAlexNetEncoder(MultiLayerEncoder):
                 # each pooling layer marks the end of the current block
                 block += 1
 
-            modules[name] = module
+            modules.append((name, module))
 
         return modules
 

--- a/pystiche/enc/models/vgg.py
+++ b/pystiche/enc/models/vgg.py
@@ -64,9 +64,9 @@ class MultiLayerVGGEncoder(MultiLayerEncoder):
         base_model.load_state_dict(state_dict)
         model = base_model.features
 
-        modules = OrderedDict()
+        modules = []
         if self.internal_preprocessing:
-            modules["preprocessing"] = get_preprocessor(self.weights)
+            modules.append(("preprocessing", get_preprocessor(self.weights)))
 
         block = depth = 1
         for module in model.children():
@@ -86,7 +86,7 @@ class MultiLayerVGGEncoder(MultiLayerEncoder):
                 block += 1
                 depth = 1
 
-            modules[name] = module
+            modules.append((name, module))
 
         return modules
 

--- a/pystiche/enc/multi_layer_encoder.py
+++ b/pystiche/enc/multi_layer_encoder.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from copy import copy
-from typing import Collection, Dict, Iterator, Optional, Sequence, Tuple
+from typing import Collection, Iterator, Optional, Sequence, Tuple
 
 import torch
 from torch import nn
@@ -15,7 +15,7 @@ __all__ = ["MultiLayerEncoder", "SingleLayerEncoder"]
 
 
 class MultiLayerEncoder(pystiche.Module):
-    def __init__(self, modules: Dict[str, nn.Module]) -> None:
+    def __init__(self, modules: Sequence[Tuple[str, nn.Module]]) -> None:
         super().__init__(named_children=modules)
         self.registered_layers = set()
         # TODO: rename to storage

--- a/pystiche/loss/multi_op.py
+++ b/pystiche/loss/multi_op.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterator, Tuple, Union
+from typing import Iterator, Sequence, Tuple, Union
 
 import torch
 
@@ -12,20 +12,26 @@ __all__ = ["MultiOperatorLoss"]
 
 class MultiOperatorLoss(pystiche.Module):
     def __init__(
-        self, *args: Union[Dict[str, Operator], Operator], trim: bool = True
+        self, *named_ops: Sequence[Tuple[str, Operator]], trim: bool = True
     ) -> None:
-        if len(args) == 1 and isinstance(args[0], dict):
-            named_children = args[0]
+        info = (
+            "Please construct a MultiOperatorLoss with a sequence of named operators."
+        )
+        if len(named_ops) == 1:
+            if isinstance(named_ops[0], dict):
+                named_children = tuple(named_ops[0].items())
+                warn_deprecation(
+                    "input as dictionary of ", "named_ops", "0.4.0", info=info,
+                )
+            else:
+                named_children = named_ops[0]
             indexed_children = None
         else:
             warn_deprecation(
-                "variable number of input",
-                "*args",
-                "0.4.0",
-                info="Please construct a MultiOperatorLoss with a dictionary of named operators.",
+                "variable number of input", "*args", "0.4.0", info=info,
             )
             named_children = None
-            indexed_children = args
+            indexed_children = named_ops
 
         super().__init__(
             named_children=named_children, indexed_children=indexed_children

--- a/pystiche/loss/perceptual.py
+++ b/pystiche/loss/perceptual.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from typing import Optional
 
 import torch
@@ -22,20 +21,20 @@ class _PerceptualLoss(MultiOperatorLoss):
         regularization: Optional[RegularizationOperator] = None,
         trim: bool = True,
     ) -> None:
-        ops = []
+        named_ops = []
         if content_loss is not None:
-            ops.append((self._CONTENT_LOSS_ID, content_loss))
+            named_ops.append((self._CONTENT_LOSS_ID, content_loss))
         if style_loss is not None:
-            ops.append((self._STYLE_LOSS_ID, style_loss))
+            named_ops.append((self._STYLE_LOSS_ID, style_loss))
 
-        if not ops:
+        if not named_ops:
             msg = "PerceptualLoss requires at least content_loss or style_loss."
             raise RuntimeError(msg)
 
         if regularization is not None:
-            ops.append((self._REGULARIZATION_ID, regularization))
+            named_ops.append((self._REGULARIZATION_ID, regularization))
 
-        super().__init__(OrderedDict(ops), trim=trim)
+        super().__init__(named_ops, trim=trim)
 
     @property
     def has_content_loss(self) -> bool:

--- a/pystiche/ops/container.py
+++ b/pystiche/ops/container.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Callable, Dict, Sequence, Union
+from typing import Callable, Sequence, Tuple, Union
 
 import torch
 
@@ -18,7 +18,7 @@ __all__ = [
 
 
 class OperatorContainer(Operator):
-    def __init__(self, named_ops: Dict[str, Operator], score_weight=1e0):
+    def __init__(self, named_ops: Sequence[Tuple[str, Operator]], score_weight=1e0):
         super().__init__(score_weight=score_weight)
         self.add_named_modules(named_ops)
 
@@ -41,9 +41,10 @@ class SameOperatorContainer(OperatorContainer):
         score_weight=1e0,
     ) -> None:
         op_weights = self._parse_op_weights(op_weights, len(names))
-        named_ops = OrderedDict(
-            [(name, get_op(name, weight)) for name, weight in zip(names, op_weights)]
-        )
+        named_ops = [
+            (name, get_op(name, weight)) for name, weight in zip(names, op_weights)
+        ]
+
         super().__init__(named_ops, score_weight=score_weight)
 
     @staticmethod
@@ -124,7 +125,7 @@ class MultiRegionOperator(SameOperatorContainer):
     def __init__(
         self,
         regions: Sequence[str],
-        get_op: Callable[[Encoder, float], Operator],
+        get_op: Callable[[str, float], Operator],
         region_weights: Union[str, Sequence[float]] = "sum",
         score_weight: float = 1e0,
     ):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -473,9 +473,7 @@ class TestModules(PysticheTestCase):
                 pass
 
         childs = (nn.Conv2d(1, 1, 1), nn.ReLU())
-        named_children = OrderedDict(
-            [(f"child{idx}", child) for idx, child in enumerate(childs)]
-        )
+        named_children = [(f"child{idx}", child) for idx, child in enumerate(childs)]
         indexed_children = childs
 
         test_module = TestModule(named_children=named_children)

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from itertools import chain, combinations
 
 import torch
@@ -30,7 +29,7 @@ class TestMultiOp(PysticheTestCase):
                 pass
 
         named_ops = [(str(idx), TestOperator()) for idx in range(3)]
-        multi_op_loss = loss.MultiOperatorLoss(OrderedDict(named_ops))
+        multi_op_loss = loss.MultiOperatorLoss(named_ops)
 
         actuals = multi_op_loss.named_children()
         desireds = named_ops
@@ -45,16 +44,14 @@ class TestMultiOp(PysticheTestCase):
                 pass
 
         layers = [str(idx) for idx in range(3)]
-        modules = OrderedDict([(layer, nn.Module()) for layer in layers])
+        modules = [(layer, nn.Module()) for layer in layers]
         multi_layer_encoder = MultiLayerEncoder(modules)
 
-        ops = OrderedDict(
+        ops = (
             (
-                (
-                    "op",
-                    TestOperator(
-                        multi_layer_encoder.extract_single_layer_encoder(layers[0])
-                    ),
+                "op",
+                TestOperator(
+                    multi_layer_encoder.extract_single_layer_encoder(layers[0])
                 ),
             ),
         )
@@ -76,7 +73,7 @@ class TestMultiOp(PysticheTestCase):
         input = torch.tensor(0.0)
 
         named_ops = [(str(idx), TestOperator(idx + 1.0)) for idx in range(3)]
-        multi_op_loss = loss.MultiOperatorLoss(OrderedDict(named_ops))
+        multi_op_loss = loss.MultiOperatorLoss(named_ops)
 
         actual = multi_op_loss(input)
         desired = pystiche.LossDict([(name, input + op.bias) for name, op in named_ops])
@@ -91,20 +88,16 @@ class TestMultiOp(PysticheTestCase):
                 return torch.mean(input_repr)
 
         count = ForwardPassCounter()
-        modules = OrderedDict((("count", count),))
+        modules = (("count", count),)
         multi_layer_encoder = MultiLayerEncoder(modules)
 
-        ops = OrderedDict(
-            [
-                (
-                    str(idx),
-                    TestOperator(
-                        multi_layer_encoder.extract_single_layer_encoder("count")
-                    ),
-                )
-                for idx in range(3)
-            ]
-        )
+        ops = [
+            (
+                str(idx),
+                TestOperator(multi_layer_encoder.extract_single_layer_encoder("count")),
+            )
+            for idx in range(3)
+        ]
         multi_op_loss = loss.MultiOperatorLoss(ops)
 
         torch.manual_seed(0)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 import torch
 from torch import nn
 from torch.nn.functional import mse_loss
@@ -70,7 +68,7 @@ class TestContainer(PysticheTestCase):
                 pass
 
         named_ops = [(str(idx), TestOperator()) for idx in range(3)]
-        op_container = ops.OperatorContainer(OrderedDict(named_ops))
+        op_container = ops.OperatorContainer(named_ops)
 
         actuals = op_container.named_children()
         desireds = named_ops
@@ -88,7 +86,7 @@ class TestContainer(PysticheTestCase):
         input = torch.tensor(0.0)
 
         named_ops = [(str(idx), TestOperator(idx + 1.0)) for idx in range(3)]
-        op_container = ops.OperatorContainer(OrderedDict(named_ops))
+        op_container = ops.OperatorContainer(named_ops)
 
         actual = op_container(input)
         desired = pystiche.LossDict([(name, input + op.bias) for name, op in named_ops])
@@ -104,7 +102,7 @@ class TestContainer(PysticheTestCase):
                 return image + self.bias
 
         named_ops = [(str(idx), TestOperator(idx + 1.0)) for idx in range(3)]
-        op_container = ops.OperatorContainer(OrderedDict(named_ops))
+        op_container = ops.OperatorContainer(named_ops)
 
         for name, _ in named_ops:
             actual = op_container[name]
@@ -183,7 +181,7 @@ class TestContainer(PysticheTestCase):
             return TestOperator(encoder, score_weight=score_weight)
 
         layers = [str(index) for index in range(3)]
-        modules = OrderedDict([(layer, nn.Module()) for layer in layers])
+        modules = [(layer, nn.Module()) for layer in layers]
         multi_layer_encoder = MultiLayerEncoder(modules)
 
         multi_layer_enc_op = ops.MultiLayerEncodingOperator(
@@ -214,7 +212,7 @@ class TestContainer(PysticheTestCase):
         image = torch.rand(1, 3, 128, 128)
 
         layers = [str(index) for index in range(3)]
-        modules = OrderedDict([(layer, nn.Conv2d(3, 3, 1)) for layer in layers])
+        modules = [(layer, nn.Conv2d(3, 3, 1)) for layer in layers]
         multi_layer_encoder = MultiLayerEncoder(modules)
 
         multi_layer_enc_op = ops.MultiLayerEncodingOperator(


### PR DESCRIPTION
Instead of `named_children: Dict[str, nn.Module]`, `named_children: Sequence[Tuple[str, nn.Module]]` should be used after this.  