### PR TITLE
Refactor deprecation warnings

### DIFF
--- a/pystiche/core/_meta.py
+++ b/pystiche/core/_meta.py
@@ -1,5 +1,7 @@
+import warnings
+
 from pystiche import meta
-from pystiche.misc import build_deprecation_message, warn_deprecation
+from pystiche.misc import build_deprecation_message
 
 
 def deprecation(fn):
@@ -11,7 +13,7 @@ def deprecation(fn):
     )
 
     def wrapper(*args, **kwargs):
-        warn_deprecation(msg)
+        warnings.warn(msg)
         return fn(*args, **kwargs)
 
     return wrapper

--- a/pystiche/core/_meta.py
+++ b/pystiche/core/_meta.py
@@ -5,8 +5,7 @@ from pystiche.misc import build_deprecation_message, warn_deprecation
 def deprecation(fn):
     name = f"{fn.__name__}()"
     msg = build_deprecation_message(
-        "function",
-        f"pystiche.{name}",
+        f"The function pystiche.{name}",
         "0.4.0",
         info=f"It was moved to pystiche.meta.{name}.",
     )

--- a/pystiche/core/_modules.py
+++ b/pystiche/core/_modules.py
@@ -32,10 +32,11 @@ class Module(nn.Module, ComplexObject):
     def add_named_modules(self, modules: Sequence[Tuple[str, nn.Module]]) -> None:
         if isinstance(modules, dict):
             warn_deprecation(
-                "parameter named_modules as ",
-                "dict",
-                "0.4",
-                info="To achieve the same behavior you can pass tuple(modules.items())",
+                "Adding named_modules from a dictionary" "0.4",
+                info=(
+                    "To achieve the same behavior you can pass "
+                    "tuple(modules.items()) instead."
+                ),
             )
             modules = tuple(modules.items())
         for name, module in modules:

--- a/pystiche/core/_modules.py
+++ b/pystiche/core/_modules.py
@@ -1,10 +1,11 @@
+import warnings
 from abc import abstractmethod
 from typing import Any, Optional, Sequence, Tuple
 
 import torch
 from torch import nn
 
-from pystiche.misc import warn_deprecation
+from pystiche.misc import build_deprecation_message
 
 from ._objects import ComplexObject
 
@@ -31,13 +32,15 @@ class Module(nn.Module, ComplexObject):
 
     def add_named_modules(self, modules: Sequence[Tuple[str, nn.Module]]) -> None:
         if isinstance(modules, dict):
-            warn_deprecation(
-                "Adding named_modules from a dictionary" "0.4",
+            msg = build_deprecation_message(
+                "Adding named_modules from a dictionary",
+                "0.4",
                 info=(
                     "To achieve the same behavior you can pass "
                     "tuple(modules.items()) instead."
                 ),
             )
+            warnings.warn(msg)
             modules = tuple(modules.items())
         for name, module in modules:
             self.add_module(name, module)

--- a/pystiche/core/_objects.py
+++ b/pystiche/core/_objects.py
@@ -78,7 +78,7 @@ class ComplexObject(ABC):
 class Object(ComplexObject):
     def __init__(self, *args, **kwargs):
         warn_deprecation(
-            "class", "Object", "0.4", info="It was renamed to ComplexObject."
+            "The class Object", "0.4", info="It was renamed to ComplexObject."
         )
         super().__init__(*args, **kwargs)
 

--- a/pystiche/core/_objects.py
+++ b/pystiche/core/_objects.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC
 from collections import OrderedDict
 from copy import copy
@@ -18,7 +19,12 @@ import torch
 from torch import nn
 
 from pystiche.meta import is_scalar_tensor
-from pystiche.misc import build_fmtstr, build_obj_str, format_dict, warn_deprecation
+from pystiche.misc import (
+    build_deprecation_message,
+    build_fmtstr,
+    build_obj_str,
+    format_dict,
+)
 
 __all__ = ["ComplexObject", "TensorStorage", "LossDict", "TensorKey"]
 
@@ -77,9 +83,10 @@ class ComplexObject(ABC):
 
 class Object(ComplexObject):
     def __init__(self, *args, **kwargs):
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The class Object", "0.4", info="It was renamed to ComplexObject."
         )
+        warnings.warn(msg)
         super().__init__(*args, **kwargs)
 
 

--- a/pystiche/enc/models/alexnet.py
+++ b/pystiche/enc/models/alexnet.py
@@ -1,10 +1,11 @@
+import warnings
 from collections import OrderedDict
 
 from torch import nn
 from torch.utils import model_zoo
 from torchvision.models import alexnet
 
-from pystiche.misc import warn_deprecation
+from pystiche.misc import build_deprecation_message
 
 from ..multi_layer_encoder import MultiLayerEncoder
 from ..preprocessing import get_preprocessor
@@ -66,11 +67,12 @@ class MultiLayerAlexNetEncoder(MultiLayerEncoder):
 
 class AlexNetEncoder(MultiLayerAlexNetEncoder):
     def __init__(self, *args, **kwargs):
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The class AlexNetEncoder",
             "0.4.0",
             info="It was replaced by MultiLayerAlexNetEncoder.",
         )
+        warnings.warn(msg)
         super().__init__(*args, **kwargs)
 
 
@@ -81,9 +83,10 @@ def alexnet_multi_layer_encoder(
 
 
 def alexnet_encoder(*args, **kwargs):
-    warn_deprecation(
+    msg = build_deprecation_message(
         "The function alexnet_encoder",
         "0.4.0",
         info="It was replaced by alexnet_multi_layer_encoder.",
     )
+    warnings.warn(msg)
     return alexnet_multi_layer_encoder(*args, **kwargs)

--- a/pystiche/enc/models/alexnet.py
+++ b/pystiche/enc/models/alexnet.py
@@ -67,8 +67,7 @@ class MultiLayerAlexNetEncoder(MultiLayerEncoder):
 class AlexNetEncoder(MultiLayerAlexNetEncoder):
     def __init__(self, *args, **kwargs):
         warn_deprecation(
-            "class",
-            "AlexNetEncoder",
+            "The class AlexNetEncoder",
             "0.4.0",
             info="It was replaced by MultiLayerAlexNetEncoder.",
         )
@@ -83,9 +82,8 @@ def alexnet_multi_layer_encoder(
 
 def alexnet_encoder(*args, **kwargs):
     warn_deprecation(
-        "function",
-        "alexnet_encoder",
+        "The function alexnet_encoder",
         "0.4.0",
-        info="It was replaced by alexnet_multi_layer_encoder",
+        info="It was replaced by alexnet_multi_layer_encoder.",
     )
     return alexnet_multi_layer_encoder(*args, **kwargs)

--- a/pystiche/enc/models/vgg.py
+++ b/pystiche/enc/models/vgg.py
@@ -1,11 +1,12 @@
 import re
+import warnings
 from collections import OrderedDict
 
 import torchvision
 from torch import nn
 from torch.utils import model_zoo
 
-from pystiche.misc import warn_deprecation
+from pystiche.misc import build_deprecation_message
 
 from ..multi_layer_encoder import MultiLayerEncoder, SingleLayerEncoder
 from ..preprocessing import get_preprocessor
@@ -110,7 +111,7 @@ class MultiLayerVGGEncoder(MultiLayerEncoder):
             layer = f"{type}{block}"
             if depth is not None:
                 layer += f"_{depth}"
-            warn_deprecation(
+            msg = build_deprecation_message(
                 f"The layer pattern {old_layer}",
                 "0.4.0",
                 info=(
@@ -119,16 +120,18 @@ class MultiLayerVGGEncoder(MultiLayerEncoder):
                 ),
                 url="https://github.com/pmeier/pystiche/issues/125",
             )
+            warnings.warn(msg)
         return super().extract_single_layer_encoder(layer)
 
 
 class VGGEncoder(MultiLayerVGGEncoder):
     def __init__(self, *args, **kwargs):
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The class VGGEncoder",
             "0.4.0",
             info="It was replaced by MultiLayerVGGEncoder.",
         )
+        warnings.warn(msg)
         super().__init__(*args, **kwargs)
 
 
@@ -174,11 +177,12 @@ def vgg19_bn_multi_layer_encoder(**kwargs) -> MultiLayerVGGEncoder:
 
 
 def _vgg_encoder(arch: str, **kwargs) -> MultiLayerVGGEncoder:
-    warn_deprecation(
+    msg = build_deprecation_message(
         f"The function {arch}_encoder",
         "0.4.0",
         info=f"It was replaced by {arch}_multi_layer_encoder.",
     )
+    warnings.warn(msg)
     return MultiLayerVGGEncoder(arch, **kwargs)
 
 

--- a/pystiche/enc/models/vgg.py
+++ b/pystiche/enc/models/vgg.py
@@ -111,8 +111,7 @@ class MultiLayerVGGEncoder(MultiLayerEncoder):
             if depth is not None:
                 layer += f"_{depth}"
             warn_deprecation(
-                "layer pattern",
-                old_layer,
+                f"The layer pattern {old_layer}",
                 "0.4.0",
                 info=(
                     f"Please remove the underscore between the layer type and the "
@@ -126,8 +125,7 @@ class MultiLayerVGGEncoder(MultiLayerEncoder):
 class VGGEncoder(MultiLayerVGGEncoder):
     def __init__(self, *args, **kwargs):
         warn_deprecation(
-            "class",
-            "VGGEncoder",
+            "The class VGGEncoder",
             "0.4.0",
             info="It was replaced by MultiLayerVGGEncoder.",
         )
@@ -177,10 +175,9 @@ def vgg19_bn_multi_layer_encoder(**kwargs) -> MultiLayerVGGEncoder:
 
 def _vgg_encoder(arch: str, **kwargs) -> MultiLayerVGGEncoder:
     warn_deprecation(
-        "function",
-        f"{arch}_encoder",
+        f"The function {arch}_encoder",
         "0.4.0",
-        info=f"It was replaced by {arch}_multi_layer_encoder",
+        info=f"It was replaced by {arch}_multi_layer_encoder.",
     )
     return MultiLayerVGGEncoder(arch, **kwargs)
 

--- a/pystiche/enc/multi_layer_encoder.py
+++ b/pystiche/enc/multi_layer_encoder.py
@@ -85,8 +85,7 @@ class MultiLayerEncoder(pystiche.Module):
 
     def __getitem__(self, layer: str) -> "SingleLayerEncoder":
         warn_deprecation(
-            "method",
-            "MultiLayerEncoder.__getitem__",
+            "Extracting a SingleLayerEncoder with bracket indexing",
             "0.4.0",
             info=(
                 "To extract a single layer encoder use MultiLayerEncoder.extract_"
@@ -109,8 +108,7 @@ class MultiLayerEncoder(pystiche.Module):
 
     def clear_cache(self):
         warn_deprecation(
-            "method",
-            "clear_cache()",
+            "The method clear_cache()",
             "0.4.0",
             info="It was renamed to empty_storage().",
         )

--- a/pystiche/enc/multi_layer_encoder.py
+++ b/pystiche/enc/multi_layer_encoder.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import OrderedDict
 from copy import copy
 from typing import Collection, Iterator, Optional, Sequence, Tuple
@@ -6,7 +7,7 @@ import torch
 from torch import nn
 
 import pystiche
-from pystiche.misc import warn_deprecation
+from pystiche.misc import build_deprecation_message
 
 from .encoder import Encoder
 from .guides import propagate_guide
@@ -84,7 +85,7 @@ class MultiLayerEncoder(pystiche.Module):
         return SingleLayerEncoder(self, layer)
 
     def __getitem__(self, layer: str) -> "SingleLayerEncoder":
-        warn_deprecation(
+        msg = build_deprecation_message(
             "Extracting a SingleLayerEncoder with bracket indexing",
             "0.4.0",
             info=(
@@ -92,6 +93,7 @@ class MultiLayerEncoder(pystiche.Module):
                 "single_layer_encoder() instead."
             ),
         )
+        warnings.warn(msg)
         return self.extract_single_layer_encoder(layer)
 
     def encode(self, input: torch.Tensor):
@@ -107,11 +109,12 @@ class MultiLayerEncoder(pystiche.Module):
         self._storage = {}
 
     def clear_cache(self):
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The method clear_cache()",
             "0.4.0",
             info="It was renamed to empty_storage().",
         )
+        warnings.warn(msg)
         self.empty_storage()
 
     def trim(self, layers: Optional[Collection[str]] = None):

--- a/pystiche/image/io.py
+++ b/pystiche/image/io.py
@@ -1,3 +1,4 @@
+import warnings
 from os import listdir, path
 from typing import Any, Optional, Tuple, Union
 
@@ -7,7 +8,7 @@ import torch
 from torchvision.transforms.functional import to_pil_image as _to_pil_image
 from torchvision.transforms.functional import to_tensor as _to_tensor
 
-from pystiche.misc import warn_deprecation
+from pystiche.misc import build_deprecation_message
 
 from .utils import (
     calculate_aspect_ratio,
@@ -89,11 +90,12 @@ def _pil_resize(
         raise RuntimeError
 
     if kwargs:
-        warn_deprecation(
+        msg = build_deprecation_message(
             "Passing additional parameters via **resize_kwargs",
             "0.4.0",
             info="The keyword arguments are ignored",
         )
+        warnings.warn(msg)
 
     return image.resize((width, height))
 

--- a/pystiche/image/io.py
+++ b/pystiche/image/io.py
@@ -90,8 +90,7 @@ def _pil_resize(
 
     if kwargs:
         warn_deprecation(
-            "parameter",
-            "resize_kwargs",
+            "Passing additional parameters via **resize_kwargs",
             "0.4.0",
             info="The keyword arguments are ignored",
         )

--- a/pystiche/image/processing.py
+++ b/pystiche/image/processing.py
@@ -1,10 +1,13 @@
-from pystiche.misc import warn_deprecation
+import warnings
+
+from pystiche.misc import build_deprecation_message
 
 from .transforms.processing import *  # noqa: F401, F403
 
 # If removed, also remove import in pystiche.image.__init__.py
-warn_deprecation(
+msg = build_deprecation_message(
     "The module pystiche.image.processing",
     "0.4.0",
     info="It was moved to pystiche.image.transforms.processing",
 )
+warnings.warn(msg)

--- a/pystiche/image/processing.py
+++ b/pystiche/image/processing.py
@@ -4,8 +4,7 @@ from .transforms.processing import *  # noqa: F401, F403
 
 # If removed, also remove import in pystiche.image.__init__.py
 warn_deprecation(
-    "module",
-    "pystiche.image.processing",
+    "The module pystiche.image.processing",
     "0.4.0",
     info="It was moved to pystiche.image.transforms.processing",
 )

--- a/pystiche/loss/multi_op.py
+++ b/pystiche/loss/multi_op.py
@@ -1,10 +1,11 @@
+import warnings
 from typing import Iterator, Sequence, Tuple, Union
 
 import torch
 
 import pystiche
 from pystiche.enc import MultiLayerEncoder, SingleLayerEncoder
-from pystiche.misc import warn_deprecation
+from pystiche.misc import build_deprecation_message
 from pystiche.ops import EncodingOperator, Operator
 
 __all__ = ["MultiOperatorLoss"]
@@ -20,18 +21,20 @@ class MultiOperatorLoss(pystiche.Module):
         if len(named_ops) == 1:
             if isinstance(named_ops[0], dict):
                 named_children = tuple(named_ops[0].items())
-                warn_deprecation(
+                msg = build_deprecation_message(
                     "Passing named_ops as dictionary", "0.4.0", info=info,
                 )
+                warnings.warn(msg)
             else:
                 named_children = named_ops[0]
             indexed_children = None
         else:
-            warn_deprecation(
+            msg = build_deprecation_message(
                 "Passing a variable number of unnamed operators via *args",
                 "0.4.0",
                 info=info,
             )
+            warnings.warn(msg)
             named_children = None
             indexed_children = named_ops
 
@@ -73,11 +76,12 @@ class MultiOperatorLoss(pystiche.Module):
         return loss
 
     def __getitem__(self, item: Union[str, int]):
-        warn_deprecation(
+        msg = build_deprecation_message(
             "Dynamic access to the modules via bracket indexing",
             "0.4.0",
             info="If you need dynamic access to the operators, use getattr() instead.",
         )
+        warnings.warn(msg)
         if isinstance(item, str):
             return self._modules[item]
         elif isinstance(item, int):
@@ -86,7 +90,10 @@ class MultiOperatorLoss(pystiche.Module):
             raise TypeError
 
     def __delitem__(self, item: Union[str, int]):
-        warn_deprecation("Deleting modules via bracket indexing", "0.4.0")
+        msg = build_deprecation_message(
+            "Deleting modules via bracket indexing", "0.4.0"
+        )
+        warnings.warn(msg)
         if isinstance(item, str):
             del self._modules[item]
         elif isinstance(item, int):

--- a/pystiche/loss/multi_op.py
+++ b/pystiche/loss/multi_op.py
@@ -21,14 +21,16 @@ class MultiOperatorLoss(pystiche.Module):
             if isinstance(named_ops[0], dict):
                 named_children = tuple(named_ops[0].items())
                 warn_deprecation(
-                    "input as dictionary of ", "named_ops", "0.4.0", info=info,
+                    "Passing named_ops as dictionary", "0.4.0", info=info,
                 )
             else:
                 named_children = named_ops[0]
             indexed_children = None
         else:
             warn_deprecation(
-                "variable number of input", "*args", "0.4.0", info=info,
+                "Passing a variable number of unnamed operators via *args",
+                "0.4.0",
+                info=info,
             )
             named_children = None
             indexed_children = named_ops
@@ -72,8 +74,7 @@ class MultiOperatorLoss(pystiche.Module):
 
     def __getitem__(self, item: Union[str, int]):
         warn_deprecation(
-            "method",
-            "__getitem__",
+            "Dynamic access to the modules via bracket indexing",
             "0.4.0",
             info="If you need dynamic access to the operators, use getattr() instead.",
         )
@@ -85,7 +86,7 @@ class MultiOperatorLoss(pystiche.Module):
             raise TypeError
 
     def __delitem__(self, item: Union[str, int]):
-        warn_deprecation("method", "__delitem__", "0.4.0")
+        warn_deprecation("Deleting modules via bracket indexing", "0.4.0")
         if isinstance(item, str):
             del self._modules[item]
         elif isinstance(item, int):

--- a/pystiche/misc/misc.py
+++ b/pystiche/misc/misc.py
@@ -332,14 +332,13 @@ def save_state_dict(
 
 
 def build_deprecation_message(
-    type: str,
-    name: str,
+    description: str,
     version: str,
     info: Optional[str] = None,
     url: Optional[str] = None,
 ) -> str:
     msg = (
-        f"The {type} {name} is deprecated since pystiche=={version} and will be "
+        f"{description} is deprecated since pystiche=={version} and will be "
         "removed in a future release."
     )
     if info is not None:
@@ -350,8 +349,10 @@ def build_deprecation_message(
 
 
 def warn_deprecation(*args: str, **kwargs: Optional[str]):
-    if len(args) == 1 and not kwargs:
+    if len(args) == 0:
+        msg = ""
+    elif len(args) == 1 and not kwargs:
         msg = args[0]
     else:
         msg = build_deprecation_message(*args, **kwargs)
-    warnings.warn(msg, UserWarning)
+    warnings.warn(msg, DeprecationWarning)

--- a/pystiche/misc/misc.py
+++ b/pystiche/misc/misc.py
@@ -349,9 +349,13 @@ def build_deprecation_message(
 
 
 def warn_deprecation(*args: str, **kwargs: Optional[str]):
-    if len(args) == 0:
-        msg = ""
-    elif len(args) == 1 and not kwargs:
+    msg = build_deprecation_message(
+        "META: The function warn_deprecation",
+        "0.4.0",
+        url="https://github.com/pmeier/pystiche/pull/189",
+    )
+    warnings.warn(msg, DeprecationWarning)
+    if len(args) == 1 and not kwargs:
         msg = args[0]
     else:
         msg = build_deprecation_message(*args, **kwargs)

--- a/pystiche/misc/misc.py
+++ b/pystiche/misc/misc.py
@@ -338,7 +338,7 @@ def build_deprecation_message(
     url: Optional[str] = None,
 ) -> str:
     msg = (
-        f"{description} is deprecated since pystiche=={version} and will be "
+        f"{description.strip()} is deprecated since pystiche=={version} and will be "
         "removed in a future release."
     )
     if info is not None:

--- a/pystiche/misc/misc.py
+++ b/pystiche/misc/misc.py
@@ -355,4 +355,4 @@ def warn_deprecation(*args: str, **kwargs: Optional[str]):
         msg = args[0]
     else:
         msg = build_deprecation_message(*args, **kwargs)
-    warnings.warn(msg, DeprecationWarning)
+    warnings.warn(msg, UserWarning)

--- a/pystiche/optim/meter.py
+++ b/pystiche/optim/meter.py
@@ -97,8 +97,7 @@ class AverageMeter(FloatMeter):
     ):
         if show_avg is not None:
             msg = build_deprecation_message(
-                "parameter",
-                "show_avg",
+                "The parameter show_avg",
                 "0.4.0",
                 info="The average is now always shown.",
             )
@@ -109,8 +108,7 @@ class AverageMeter(FloatMeter):
 
         if use_running_avg is not None:
             warn_deprecation(
-                "parameter",
-                "use_running_avg",
+                "The parameter use_running_avg",
                 "0.4.0",
                 info="It was renamed to show_local_avg.",
             )
@@ -142,34 +140,36 @@ class AverageMeter(FloatMeter):
 
     @property
     def val(self) -> float:
-        warn_deprecation("attribute", "val", "0.4.0", info="It was renamed to last_val")
+        warn_deprecation(
+            "The attribute val", "0.4.0", info="It was renamed to last_val"
+        )
         return self.global_avg
 
     @property
     def avg(self) -> float:
         warn_deprecation(
-            "attribute", "avg", "0.4.0", info="It was renamed to global_avg"
+            "The attribute avg", "0.4.0", info="It was renamed to global_avg"
         )
         return self.global_avg
 
     @property
     def min(self) -> float:
         warn_deprecation(
-            "attribute", "min", "0.4.0", info="It was renamed to global_min"
+            "The attribute min", "0.4.0", info="It was renamed to global_min"
         )
         return self.global_avg
 
     @property
     def max(self) -> float:
         warn_deprecation(
-            "attribute", "max", "0.4.0", info="It was renamed to global_max"
+            "The attribute max", "0.4.0", info="It was renamed to global_max"
         )
         return self.global_avg
 
     @property
     def running_avg(self) -> float:
         warn_deprecation(
-            "attribute", "running_avg", "0.4.0", info="It was renamed to local_avg"
+            "The attribute running_avg", "0.4.0", info="It was renamed to local_avg"
         )
         return self.local_avg
 
@@ -189,7 +189,7 @@ class LossMeter(AverageMeter):
 class TimeMeter(AverageMeter):
     def __init__(self, name: str = "time", fmt: str = "{:3.1f}", **kwargs: Any) -> None:
         warn_deprecation(
-            "class", "TimeMeter", "0.4.0", info="Please use AverageMeter instead."
+            "The class TimeMeter", "0.4.0", info="Please use AverageMeter instead."
         )
         super().__init__(name, fmt=fmt, **kwargs)
 
@@ -273,8 +273,7 @@ class ProgressMeter(Meter):
     ) -> None:
         if num_batches is not None:
             warn_deprecation(
-                "parameter",
-                "num_batches",
+                "The parameter num_batches",
                 "0.4.0",
                 info="It was renamed to total_count.",
             )

--- a/pystiche/optim/meter.py
+++ b/pystiche/optim/meter.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict, deque
 from datetime import datetime, timedelta
@@ -6,7 +7,7 @@ from typing import Any, Callable, Collection, Optional, Union
 import torch
 
 import pystiche
-from pystiche.misc import build_deprecation_message, build_fmtstr, warn_deprecation
+from pystiche.misc import build_deprecation_message, build_fmtstr
 
 __all__ = [
     "Meter",
@@ -102,16 +103,17 @@ class AverageMeter(FloatMeter):
                 info="The average is now always shown.",
             )
             if show_avg:
-                warn_deprecation(msg)
+                warnings.warn(msg)
             else:
                 raise RuntimeError(msg)
 
         if use_running_avg is not None:
-            warn_deprecation(
+            msg = build_deprecation_message(
                 "The parameter use_running_avg",
                 "0.4.0",
                 info="It was renamed to show_local_avg.",
             )
+            warnings.warn(msg)
             show_local_avg = use_running_avg
 
         super().__init__(name=name, window_size=window_size)
@@ -140,37 +142,42 @@ class AverageMeter(FloatMeter):
 
     @property
     def val(self) -> float:
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The attribute val", "0.4.0", info="It was renamed to last_val"
         )
+        warnings.warn(msg)
         return self.global_avg
 
     @property
     def avg(self) -> float:
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The attribute avg", "0.4.0", info="It was renamed to global_avg"
         )
+        warnings.warn(msg)
         return self.global_avg
 
     @property
     def min(self) -> float:
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The attribute min", "0.4.0", info="It was renamed to global_min"
         )
+        warnings.warn(msg)
         return self.global_avg
 
     @property
     def max(self) -> float:
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The attribute max", "0.4.0", info="It was renamed to global_max"
         )
+        warnings.warn(msg)
         return self.global_avg
 
     @property
     def running_avg(self) -> float:
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The attribute running_avg", "0.4.0", info="It was renamed to local_avg"
         )
+        warnings.warn(msg)
         return self.local_avg
 
 
@@ -188,9 +195,10 @@ class LossMeter(AverageMeter):
 
 class TimeMeter(AverageMeter):
     def __init__(self, name: str = "time", fmt: str = "{:3.1f}", **kwargs: Any) -> None:
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The class TimeMeter", "0.4.0", info="Please use AverageMeter instead."
         )
+        warnings.warn(msg)
         super().__init__(name, fmt=fmt, **kwargs)
 
 
@@ -272,11 +280,12 @@ class ProgressMeter(Meter):
         self, total_count: Optional[int] = None, num_batches: Optional[int] = None
     ) -> None:
         if num_batches is not None:
-            warn_deprecation(
+            msg = build_deprecation_message(
                 "The parameter num_batches",
                 "0.4.0",
                 info="It was renamed to total_count.",
             )
+            warnings.warn(msg)
             total_count = num_batches
 
         self.count = 0

--- a/pystiche/optim/optim.py
+++ b/pystiche/optim/optim.py
@@ -157,8 +157,7 @@ def default_transformer_optim_loop(
 ) -> nn.Module:
     if get_optimizer is not None:
         warn_deprecation(
-            "parameter",
-            "get_optimizer",
+            "The parameter get_optimizer",
             "0.4.0",
             info="You can achieve the same functionality by passing optimizer=get_optimizer(transformer).",
             url="https://github.com/pmeier/pystiche/pull/96",

--- a/pystiche/optim/optim.py
+++ b/pystiche/optim/optim.py
@@ -1,4 +1,5 @@
 import time
+import warnings
 from typing import Callable, Iterable, Optional, Tuple, Union
 
 import torch
@@ -9,7 +10,7 @@ from torch.utils.data import DataLoader
 
 import pystiche
 from pystiche.image import extract_aspect_ratio, extract_image_size
-from pystiche.misc import warn_deprecation
+from pystiche.misc import build_deprecation_message
 from pystiche.pyramid import ImagePyramid
 from pystiche.pyramid.level import PyramidLevel
 
@@ -156,12 +157,13 @@ def default_transformer_optim_loop(
     ] = None,
 ) -> nn.Module:
     if get_optimizer is not None:
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The parameter get_optimizer",
             "0.4.0",
             info="You can achieve the same functionality by passing optimizer=get_optimizer(transformer).",
             url="https://github.com/pmeier/pystiche/pull/96",
         )
+        warnings.warn(msg)
         optimizer = get_optimizer(transformer)
 
     if optimizer is None:

--- a/pystiche/papers/gatys_ecker_bethge_2015/loss.py
+++ b/pystiche/papers/gatys_ecker_bethge_2015/loss.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Callable, Dict, Optional, Sequence, Union
 
 import torch
@@ -6,7 +7,7 @@ from torch.nn.functional import mse_loss
 import pystiche
 from pystiche.enc import Encoder, MultiLayerEncoder
 from pystiche.loss import PerceptualLoss
-from pystiche.misc import warn_deprecation
+from pystiche.misc import build_deprecation_message
 from pystiche.ops import (
     EncodingOperator,
     GramOperator,
@@ -130,11 +131,12 @@ class GatysEckerBethge2015PerceptualLoss(PerceptualLoss):
         content_loss: GatysEckerBethge2015MSEEncodingOperator,
         style_loss: GatysEckerBethge2015StyleLoss,
     ):
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The class GatysEckerBethge2015PerceptualLoss",
             "0.4.0",
             info="It can be replaced by pystiche.loss.PerceptualLoss.",
         )
+        warnings.warn(msg)
         super().__init__(content_loss, style_loss)
 
 

--- a/pystiche/papers/gatys_ecker_bethge_2015/loss.py
+++ b/pystiche/papers/gatys_ecker_bethge_2015/loss.py
@@ -131,8 +131,7 @@ class GatysEckerBethge2015PerceptualLoss(PerceptualLoss):
         style_loss: GatysEckerBethge2015StyleLoss,
     ):
         warn_deprecation(
-            "class",
-            "GatysEckerBethge2015PerceptualLoss",
+            "The class GatysEckerBethge2015PerceptualLoss",
             "0.4.0",
             info="It can be replaced by pystiche.loss.PerceptualLoss.",
         )

--- a/pystiche/papers/gatys_et_al_2017/loss.py
+++ b/pystiche/papers/gatys_et_al_2017/loss.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Callable, Dict, Optional, Sequence, Union
 
 import torch
@@ -5,7 +6,7 @@ import torch
 import pystiche
 from pystiche.enc import Encoder, MultiLayerEncoder
 from pystiche.loss import GuidedPerceptualLoss, PerceptualLoss
-from pystiche.misc import warn_deprecation
+from pystiche.misc import build_deprecation_message
 from pystiche.ops import (
     EncodingComparisonGuidance,
     EncodingOperator,
@@ -147,11 +148,12 @@ class GatysEtAl2017PerceptualLoss(PerceptualLoss):
     def __init__(
         self, content_loss: MSEEncodingOperator, style_loss: GatysEtAl2017StyleLoss,
     ):
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The class GatysEtAl2017PerceptualLoss",
             "0.4.0",
             info="It can be replaced by pystiche.loss.PerceptualLoss.",
         )
+        warnings.warn(msg)
         super().__init__(content_loss, style_loss)
 
 
@@ -185,11 +187,12 @@ class GatysEtAl2017GuidedPerceptualLoss(GuidedPerceptualLoss):
     def __init__(
         self, content_loss: MSEEncodingOperator, style_loss: GatysEtAl2017StyleLoss,
     ):
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The class GatysEtAl2017GuidedPerceptualLoss",
             "0.4.0",
             info="It can be replaced by pystiche.loss.PerceptualLoss.",
         )
+        warnings.warn(msg)
         super().__init__(content_loss, style_loss)
 
 

--- a/pystiche/papers/gatys_et_al_2017/loss.py
+++ b/pystiche/papers/gatys_et_al_2017/loss.py
@@ -148,8 +148,7 @@ class GatysEtAl2017PerceptualLoss(PerceptualLoss):
         self, content_loss: MSEEncodingOperator, style_loss: GatysEtAl2017StyleLoss,
     ):
         warn_deprecation(
-            "class",
-            "GatysEtAl2017PerceptualLoss",
+            "The class GatysEtAl2017PerceptualLoss",
             "0.4.0",
             info="It can be replaced by pystiche.loss.PerceptualLoss.",
         )
@@ -187,8 +186,7 @@ class GatysEtAl2017GuidedPerceptualLoss(GuidedPerceptualLoss):
         self, content_loss: MSEEncodingOperator, style_loss: GatysEtAl2017StyleLoss,
     ):
         warn_deprecation(
-            "class",
-            "GatysEtAl2017GuidedPerceptualLoss",
+            "The class GatysEtAl2017GuidedPerceptualLoss",
             "0.4.0",
             info="It can be replaced by pystiche.loss.PerceptualLoss.",
         )

--- a/pystiche/papers/johnson_alahi_li_2016/loss.py
+++ b/pystiche/papers/johnson_alahi_li_2016/loss.py
@@ -192,8 +192,7 @@ class JohnsonAlahiLi2016PerceptualLoss(PerceptualLoss):
         regularization: TotalVariationOperator,
     ) -> None:
         warn_deprecation(
-            "class",
-            "JohnsonAlahiLi2016PerceptualLoss",
+            "The class JohnsonAlahiLi2016PerceptualLoss",
             "0.4.0",
             info="It can be replaced by pystiche.loss.PerceptualLoss.",
         )

--- a/pystiche/papers/johnson_alahi_li_2016/loss.py
+++ b/pystiche/papers/johnson_alahi_li_2016/loss.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Dict, Optional, Sequence, Union
 
 import torch
@@ -5,7 +6,7 @@ import torch
 import pystiche.ops.functional as F
 from pystiche.enc import Encoder, MultiLayerEncoder
 from pystiche.loss import PerceptualLoss
-from pystiche.misc import warn_deprecation
+from pystiche.misc import build_deprecation_message
 from pystiche.ops import (
     GramOperator,
     MSEEncodingOperator,
@@ -191,11 +192,12 @@ class JohnsonAlahiLi2016PerceptualLoss(PerceptualLoss):
         style_loss: MultiLayerEncodingOperator,
         regularization: TotalVariationOperator,
     ) -> None:
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The class JohnsonAlahiLi2016PerceptualLoss",
             "0.4.0",
             info="It can be replaced by pystiche.loss.PerceptualLoss.",
         )
+        warnings.warn(msg)
         super().__init__(content_loss, style_loss, regularization=regularization)
 
 

--- a/pystiche/papers/li_wand_2016/loss.py
+++ b/pystiche/papers/li_wand_2016/loss.py
@@ -205,8 +205,7 @@ class LiWand2016PerceptualLoss(PerceptualLoss):
         regularization: LiWand2016TotalVariationOperator,
     ):
         warn_deprecation(
-            "class",
-            "LiWand2016PerceptualLoss",
+            "The class LiWand2016PerceptualLoss",
             "0.4.0",
             info="It can be replaced by pystiche.loss.PerceptualLoss.",
         )

--- a/pystiche/papers/li_wand_2016/loss.py
+++ b/pystiche/papers/li_wand_2016/loss.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
 import torch
@@ -7,7 +8,7 @@ import pystiche
 import pystiche.ops.functional as F
 from pystiche.enc import Encoder, MultiLayerEncoder
 from pystiche.loss import PerceptualLoss
-from pystiche.misc import warn_deprecation
+from pystiche.misc import build_deprecation_message
 from pystiche.ops import (
     MRFOperator,
     MSEEncodingOperator,
@@ -204,11 +205,12 @@ class LiWand2016PerceptualLoss(PerceptualLoss):
         style_loss: MultiLayerEncodingOperator,
         regularization: LiWand2016TotalVariationOperator,
     ):
-        warn_deprecation(
+        msg = build_deprecation_message(
             "The class LiWand2016PerceptualLoss",
             "0.4.0",
             info="It can be replaced by pystiche.loss.PerceptualLoss.",
         )
+        warnings.warn(msg)
         super().__init__(
             content_loss, style_loss, regularization=regularization,
         )

--- a/pystiche/typing.py
+++ b/pystiche/typing.py
@@ -20,8 +20,7 @@ __all__ = [
 ]
 
 warn_deprecation(
-    "module",
-    "pystiche.typing",
+    "The module pystiche.typing",
     "0.4.0",
     info="The functionality was moved to pystiche.meta.",
 )

--- a/pystiche/typing.py
+++ b/pystiche/typing.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pystiche.meta import (
     ConvModule,
     ConvModuleMeta,
@@ -7,7 +9,7 @@ from pystiche.meta import (
     is_conv_module,
     is_pool_module,
 )
-from pystiche.misc import warn_deprecation
+from pystiche.misc import build_deprecation_message
 
 __all__ = [
     "TensorMeta",
@@ -19,8 +21,10 @@ __all__ = [
     "PoolModuleMeta",
 ]
 
-warn_deprecation(
+
+msg = build_deprecation_message(
     "The module pystiche.typing",
     "0.4.0",
     info="The functionality was moved to pystiche.meta.",
 )
+warnings.warn(msg)


### PR DESCRIPTION
1. This deprecates the function `pystiche.misc.warn_deprecation` since using this function hides the actual location the warning was issued.
2. This merges the parameters `type` and `name` of `pystiche.misc.build_deprecation_message` into `description`. This allows for more flexibility in the deprecation messages. 