### PR TITLE
Fix errors after new PyTorch release (1.5.0 / 0.6.0)

### DIFF
--- a/docs/rtd_torch_requirements.txt
+++ b/docs/rtd_torch_requirements.txt
@@ -1,2 +1,2 @@
-https://download.pytorch.org/whl/cpu/torch-1.4.0%2Bcpu-cp36-cp36m-linux_x86_64.whl
-https://download.pytorch.org/whl/cpu/torchvision-0.5.0%2Bcpu-cp36-cp36m-linux_x86_64.whl
+https://download.pytorch.org/whl/cpu/torch-1.5.0%2Bcpu-cp36-cp36m-linux_x86_64.whl
+https://download.pytorch.org/whl/cpu/torchvision-0.6.0%2Bcpu-cp36-cp36m-linux_x86_64.whl

--- a/pystiche/image/transforms/functional/_motif.py
+++ b/pystiche/image/transforms/functional/_motif.py
@@ -34,7 +34,7 @@ def _create_motif_shearing_matrix(
         (0.0, np.cos(angle), 0.0),
         (0.0, 0.0, 1.0),
     )
-    return torch.tensor(shearing_matrix)
+    return torch.tensor(shearing_matrix, dtype=torch.float32)
 
 
 def _create_motif_rotation_matrix(
@@ -48,7 +48,7 @@ def _create_motif_rotation_matrix(
         (np.sin(angle), np.cos(angle), 0.0),
         (0.0, 0.0, 1.0),
     )
-    return torch.tensor(rotation_matrix)
+    return torch.tensor(rotation_matrix, dtype=torch.float32)
 
 
 def _create_motif_scaling_matrix(
@@ -56,7 +56,7 @@ def _create_motif_scaling_matrix(
 ) -> torch.Tensor:
     factor_vert, factor_horz = to_2d_arg(factor)
     scaling_matrix = ((factor_horz, 0.0, 0.0), (0.0, factor_vert, 0.0), (0.0, 0.0, 1.0))
-    return torch.tensor(scaling_matrix)
+    return torch.tensor(scaling_matrix, dtype=torch.float32)
 
 
 def _create_motif_translation_matrix(
@@ -70,7 +70,7 @@ def _create_motif_translation_matrix(
         (0.0, 1.0, translation_vert),
         (0.0, 0.0, 1.0),
     )
-    return torch.tensor(translation_matrix)
+    return torch.tensor(translation_matrix, dtype=torch.float32)
 
 
 def _calculate_image_center(image_size: Tuple[int, int]) -> Tuple[float, float]:


### PR DESCRIPTION
Where as in `torch==1.4.0`

```python
import numpy as np
import torch

x = torch.tensor(np.sin(np.pi / 2))
```
`x.dtype == torch.float32`, as of `torch==1.5.0` `torch.tensor` now honors that `np.sin()` returns a `float64` and sets `x.dtype` accordingly.