### PR TITLE
Misc changes to show_image

### DIFF
--- a/pystiche/image/io.py
+++ b/pystiche/image/io.py
@@ -147,16 +147,21 @@ def write_image(
     export_to_pil(image, mode=mode).save(file, **save_kwargs)
 
 
-@force_single_image
 def show_image(
-    image: torch.Tensor,
+    image: Union[torch.Tensor, str],
     title: Optional[str] = None,
     mode: Optional[str] = None,
     size: Optional[Union[int, Tuple[int, int]]] = None,
     interpolation_mode: str = "bilinear",
     **resize_kwargs: Any,
 ):
-    image = export_to_pil(image, mode=mode)
+    if isinstance(image, torch.Tensor):
+        image = export_to_pil(image, mode=mode)
+    elif isinstance(image, str):
+        image = Image.open(image)
+    else:
+        # TODO
+        raise TypeError
 
     if size is not None:
         image = _pil_resize(image, size, interpolation_mode, **resize_kwargs)

--- a/pystiche/image/io.py
+++ b/pystiche/image/io.py
@@ -25,14 +25,19 @@ from .utils import (
 try:
     import matplotlib.pyplot as plt
 
-    def _show_pil_image(image: Image.Image) -> None:
-        plt.imshow(image)
+    def _show_pil_image(image: Image.Image, title: Optional[str] = None) -> None:
+        fig, ax = plt.subplots()
+        if title is not None:
+            ax.set_title(title)
+
+        ax.imshow(image)
+        plt.show()
 
 
 except ImportError:
 
-    def _show_pil_image(image: Image.Image) -> None:
-        image.show()
+    def _show_pil_image(image: Image.Image, title: Optional[str] = None) -> None:
+        image.show(title=title)
 
 
 __all__ = [
@@ -143,6 +148,7 @@ def write_image(
 @force_single_image
 def show_image(
     image: torch.Tensor,
+    title: Optional[str] = None,
     mode: Optional[str] = None,
     size: Optional[Union[int, Tuple[int, int]]] = None,
     interpolation_mode: str = "bilinear",
@@ -153,4 +159,4 @@ def show_image(
     if size is not None:
         image = _pil_resize(image, size, interpolation_mode, **resize_kwargs)
 
-    _show_pil_image(image)
+    _show_pil_image(image, title=title)

--- a/pystiche/image/io.py
+++ b/pystiche/image/io.py
@@ -27,6 +27,7 @@ try:
 
     def _show_pil_image(image: Image.Image, title: Optional[str] = None) -> None:
         fig, ax = plt.subplots()
+        ax.axis("off")
         if title is not None:
             ax.set_title(title)
 

--- a/pystiche/image/io.py
+++ b/pystiche/image/io.py
@@ -31,7 +31,8 @@ try:
         if title is not None:
             ax.set_title(title)
 
-        ax.imshow(image)
+        cmap = "gray" if image.mode in ("L", "1") else None
+        ax.imshow(image, cmap=cmap)
         plt.show()
 
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -164,9 +164,12 @@ class TestIo(PysticheTestCase):
         self.assertImagesAlmostEqual(actual, desired)
 
     @mock.patch("pystiche.image.io._show_pil_image")
-    def test_show_image_smoke(self, plt_mock):
+    def test_show_image_smoke(self, show_pil_image_mock):
         image = self.load_image()
         io.show_image(image)
+        io.show_image(self.default_image_file())
+        with self.assertRaises(TypeError):
+            io.show_image(None)
         io.show_image(image, size=100)
         io.show_image(image, size=(100, 200))
 


### PR DESCRIPTION
This

- adds a `title` parameter
- enables `str` input which simply opens the image from the given path
- removes the axis from the `pyplot` axes
- uses a correct color map if grayscale or binary images are shown