### PR TITLE
Fix MD5 hash of demo images

### DIFF
--- a/examples/beginner/example_nst_without_pystiche.py
+++ b/examples/beginner/example_nst_without_pystiche.py
@@ -369,13 +369,13 @@ image_root = path.expanduser(path.join("~", ".cache", "pystiche"))
 #
 #   You can download the default images here:
 #
-#   - `Content image <https://free-images.com/md/71c4/bird_wildlife_australian_bird.jpg>`_
+#   - `Content image <"https://cdn.pixabay.com/photo/2016/01/14/11/26/bird-1139734_960_720.jpg">`_
 #   - `Style image <https://cdn.pixabay.com/photo/2017/07/03/20/17/abstract-2468874_960_720.jpg>`_
 
 
 ########################################################################################
 
-content_image = read_image(path.join(image_root, "bird.jpg"))
+content_image = read_image(path.join(image_root, "bird1.jpg"))
 show_image(content_image, title="Content image")
 
 

--- a/examples/beginner/example_nst_without_pystiche.py
+++ b/examples/beginner/example_nst_without_pystiche.py
@@ -369,13 +369,13 @@ image_root = path.expanduser(path.join("~", ".cache", "pystiche"))
 #
 #   You can download the default images here:
 #
-#   - `Content image <"https://cdn.pixabay.com/photo/2016/01/14/11/26/bird-1139734_960_720.jpg">`_
+#   - `Content image <https://free-images.com/md/71c4/bird_wildlife_australian_bird.jpg>`_
 #   - `Style image <https://cdn.pixabay.com/photo/2017/07/03/20/17/abstract-2468874_960_720.jpg>`_
 
 
 ########################################################################################
 
-content_image = read_image(path.join(image_root, "bird1.jpg"))
+content_image = read_image(path.join(image_root, "bird.jpg"))
 show_image(content_image, title="Content image")
 
 

--- a/pystiche/demo.py
+++ b/pystiche/demo.py
@@ -29,7 +29,7 @@ def demo_images():
                 author="gholmz0",
                 date="09.03.2013",
                 license=PixabayLicense(),
-                md5="d42444d3cd0afa47f07066cd083d6cea",
+                md5="36e5fef725943a5d1d22b5048095da86",
             ),
             "paint": DownloadableImage(
                 "https://cdn.pixabay.com/photo/2017/07/03/20/17/abstract-2468874_960_720.jpg",
@@ -45,7 +45,7 @@ def demo_images():
                 author="12019",
                 date="09.04.2012",
                 license=PixabayLicense(),
-                md5="dda3e1d0f93f783de823b4f91129d44e",
+                md5="8c5b608bd579d931e2cfe7229840fe9b",
             ),
             "mosaic": DownloadableImage(
                 "https://upload.wikimedia.org/wikipedia/commons/2/23/Mosaic_ducks_Massimo.jpg",


### PR DESCRIPTION
This fixes #222 by adjusting the MD5 hashes of the demo images. This should have been done in #211.