### PR TITLE
Add smoke tests for demo images

### DIFF
--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -3,7 +3,7 @@ from os import path
 
 import pytest
 
-from torchvision.datasets.utils import check_integrity
+from torchvision.datasets.utils import calculate_md5
 
 from pystiche import demo
 
@@ -28,8 +28,19 @@ class TestDemo(PysticheTestCase):
 
             for image_or_guide in itertools.chain(images, *guides):
                 with self.subTest(image_or_guide=image_or_guide):
+                    file = path.join(root, image_or_guide.file)
+
                     self.assertTrue(
-                        check_integrity(
-                            path.join(root, image_or_guide.file), md5=image_or_guide.md5
-                        )
+                        path.exists(file), msg=f"File {file} does not exist."
+                    )
+
+                    actual = calculate_md5(file)
+                    desired = image_or_guide.md5
+                    self.assertEqual(
+                        actual,
+                        desired,
+                        msg=(
+                            f"The actual and desired MD5 hash of the image mismatch: "
+                            "{actual} != {desired}"
+                        ),
                     )

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,9 +1,13 @@
-from .utils import PysticheTestCase, get_tmp_dir
-import pytest
-from pystiche import demo
-from torchvision.datasets.utils import check_integrity
-from os import path
 import itertools
+from os import path
+
+import pytest
+
+from torchvision.datasets.utils import check_integrity
+
+from pystiche import demo
+
+from .utils import PysticheTestCase, get_tmp_dir
 
 
 class TestDemo(PysticheTestCase):

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,0 +1,31 @@
+from .utils import PysticheTestCase, get_tmp_dir
+import pytest
+from pystiche import demo
+from torchvision.datasets.utils import check_integrity
+from os import path
+import itertools
+
+
+class TestDemo(PysticheTestCase):
+    @pytest.mark.large_download
+    @pytest.mark.slow
+    def test_demo_images_smoke(self):
+
+        with get_tmp_dir() as root:
+            images = demo.demo_images()
+            images.download(root=root)
+            images = [image for _, image in images]
+
+            guides = [
+                [guide for _, guide in image.guides]
+                for image in images
+                if image.guides is not None
+            ]
+
+            for image_or_guide in itertools.chain(images, *guides):
+                with self.subTest(image_or_guide=image_or_guide):
+                    self.assertTrue(
+                        check_integrity(
+                            path.join(root, image_or_guide.file), md5=image_or_guide.md5
+                        )
+                    )


### PR DESCRIPTION
This should prevent MD5 mismatches (#228) from happening. 