### PR TITLE
Add type annotations to pystiche.demo

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 ; https://mypy.readthedocs.io/en/stable/config_file.html
 
 ; import discovery
-files = pystiche/core
+files = pystiche
 
 ; untyped definitions and calls
 disallow_untyped_defs = True
@@ -26,3 +26,35 @@ pretty = True
 
 [mypy-numpy]
 ignore_missing_imports = True
+
+[mypy-pystiche.data.*]
+
+ignore_errors = True
+
+[mypy-pystiche.enc.*]
+
+ignore_errors = True
+
+[mypy-pystiche.image.*]
+
+ignore_errors = True
+
+[mypy-pystiche.loss.*]
+
+ignore_errors = True
+
+[mypy-pystiche.ops.*]
+
+ignore_errors = True
+
+[mypy-pystiche.optim.*]
+
+ignore_errors = True
+
+[mypy-pystiche.papers.*]
+
+ignore_errors = True
+
+[mypy-pystiche.pyramid.*]
+
+ignore_errors = True

--- a/pystiche/demo.py
+++ b/pystiche/demo.py
@@ -12,7 +12,7 @@ from pystiche.optim import OptimLogger
 __all__ = ["demo_images", "demo_logger"]
 
 
-def demo_images():
+def demo_images() -> DownloadableImageCollection:
     return DownloadableImageCollection(
         {
             "dancing": DownloadableImage(
@@ -59,7 +59,7 @@ def demo_images():
     )
 
 
-def demo_logger():
+def demo_logger() -> OptimLogger:
     logger = logging.getLogger("demo_logger")
     logger.setLevel(logging.INFO)
 


### PR DESCRIPTION
This also reverses the `mypy` import discovery: instead of explicitly adding the files that need checking, now all files are checked by default and exceptions are configured.