### PR TITLE
Add docs strings for essential functions in pystiche.misc

### DIFF
--- a/docs/source/api/pystiche.misc.rst
+++ b/docs/source/api/pystiche.misc.rst
@@ -1,2 +1,7 @@
 ``pystiche.misc``
 =================
+
+.. automodule:: pystiche.misc
+
+.. autofunction:: get_input_image
+.. autofunction:: get_device

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,7 +92,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.coverage",
     "sphinxcontrib.bibtex",
-    # "sphinx_autodoc_typehints",
+    "sphinx_autodoc_typehints",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/pystiche/misc/misc.py
+++ b/pystiche/misc/misc.py
@@ -304,6 +304,19 @@ def get_input_image(
     content_image: Optional[torch.Tensor] = None,
     style_image: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
+    """Generates an input image for NST from the given ``starting_point``.
+
+    Args:
+        starting_point: If :class:`~torch.Tensor` returns a copy. If ``"content"`` or
+         ``"style"`` returns a copy of ``content_image`` or ``style_image``,
+         respectively. If ``"random"`` returns a white noise image with the dimensions
+         of ``content_image`` or ``style_image``, respectively. Defaults to
+         ``"content"``.
+        content_image: Content image. Only required if ``starting_point`` is
+            ``"content"`` or ``"random"``.
+        style_image: Style image. Only required if ``starting_point`` is
+            ``"style"`` or ``"random"``.
+    """
     if isinstance(starting_point, torch.Tensor):
         return starting_point.clone()
 
@@ -417,7 +430,12 @@ def warn_deprecation(
 
 
 def get_device(device: Optional[str] = None) -> torch.device:
+    """Selects a device to perform an NST on.
 
+    Args:
+        device: If ``str``, returns the corresponding :class:`~torch.device`. If
+            ``None`` selects CUDA if available and otherwise CPU. Defaults to ``None``.
+    """
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
     return torch.device(device)

--- a/setup.py
+++ b/setup.py
@@ -33,14 +33,14 @@ install_requires = (
 test_requires = ("pytest", "pyimagetest", "pillow_affine", "dill", "pytest-subtests")
 
 doc_requires = (
-    "sphinx",
-    "sphinx_autodoc_typehints",
+    "sphinx < 3.0.0",
     "sphinxcontrib-bibtex",
-    "sphinx_rtd_theme",
+    "sphinx_autodoc_typehints",
     "sphinx-gallery",
     # Install additional sphinx-gallery dependencies
     # https://sphinx-gallery.github.io/stable/index.html#install-via-pip
     "matplotlib",
+    "sphinx_rtd_theme",
 )
 
 dev_requires = (


### PR DESCRIPTION
This also locks `sphinx < 3.0.0` since [`sphinx_autodoc_typehints`](https://github.com/agronholm/sphinx-autodoc-typehints) is not (yet) compatible with newer versions.