### PR TITLE
Replace sphinx_autodoc_typehints with a native sphinx solution

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,7 +81,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.intersphinx",
     "sphinxcontrib.bibtex",
-    "sphinx_autodoc_typehints",
+    "sphinx_gallery.gen_gallery",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -91,6 +91,12 @@ templates_path = ["_templates"]
 # ignore when looking for source files. This pattern also affects html_static_path and
 # html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- autodoc configuration -------------------------------------------------------------
+
+autodoc_typehints = "description"
+
 
 # -- intersphinx configuration ---------------------------------------------------------
 
@@ -106,8 +112,6 @@ intersphinx_mapping = {
 
 
 # -- sphinx-gallery configuration ------------------------------------------------------
-
-extensions.append("sphinx_gallery.gen_gallery")
 
 plot_gallery = get_bool_env_var("PYSTICHE_PLOT_GALLERY", default=True) and not run_by_ci
 

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,8 @@ install_requires = (
 test_requires = ("pytest", "pyimagetest", "pillow_affine", "dill", "pytest-subtests")
 
 doc_requires = (
-    "sphinx < 3.0.0",
+    "sphinx>=3.0.0",
     "sphinxcontrib-bibtex",
-    "sphinx_autodoc_typehints",
     "sphinx-gallery>=0.7.0",
     # Install additional sphinx-gallery dependencies
     # https://sphinx-gallery.github.io/stable/index.html#install-via-pip


### PR DESCRIPTION
As of `sphinx>=3.0.0` type hints as part of the docstring are [supported](https://www.sphinx-doc.org/en/3.x/usage/extensions/autodoc.html#confval-autodoc_typehints).