### PR TITLE
Guard velocity calculation in default_transformer_optim_loop

### DIFF
--- a/pystiche/optim/optim.py
+++ b/pystiche/optim/optim.py
@@ -198,8 +198,8 @@ def default_transformer_optim_loop(
 
             if not quiet:
                 batch_size = input_image.size()[0]
-                image_loading_velocity = batch_size / max(loading_time, 1e-3)
-                image_processing_velocity = batch_size / max(processing_time, 1e-3)
+                image_loading_velocity = batch_size / max(loading_time, 1e-6)
+                image_processing_velocity = batch_size / max(processing_time, 1e-6)
                 # See https://github.com/pmeier/pystiche/pull/264#discussion_r430205029
                 log_fn(batch, loss, image_loading_velocity, image_processing_velocity)  # type: ignore[misc]
 

--- a/pystiche/optim/optim.py
+++ b/pystiche/optim/optim.py
@@ -198,8 +198,8 @@ def default_transformer_optim_loop(
 
             if not quiet:
                 batch_size = input_image.size()[0]
-                image_loading_velocity = batch_size / loading_time
-                image_processing_velocity = batch_size / processing_time
+                image_loading_velocity = batch_size / max(loading_time, 1e-3)
+                image_processing_velocity = batch_size / max(processing_time, 1e-3)
                 # See https://github.com/pmeier/pystiche/pull/264#discussion_r430205029
                 log_fn(batch, loss, image_loading_velocity, image_processing_velocity)  # type: ignore[misc]
 


### PR DESCRIPTION
Without it CI tests sometimes resulted in a `ZeroDivisionError`. For an example see https://ci.appveyor.com/project/pmeier/pystiche/builds/33173090/job/kw9n2q16a3m21v2a