### PR TITLE
Add documentation for pystiche.pyramid

### DIFF
--- a/docs/source/api/pystiche.image.transforms.rst
+++ b/docs/source/api/pystiche.image.transforms.rst
@@ -71,3 +71,11 @@ Resize
 
 .. autoclass:: Resize
 .. autoclass:: Rescale
+
+
+Functional
+----------
+
+.. automodule:: pystiche.image.transforms.functional
+
+.. autofunction:: resize

--- a/docs/source/api/pystiche.pyramid.rst
+++ b/docs/source/api/pystiche.pyramid.rst
@@ -9,9 +9,11 @@ Image pyramid
 
 .. autoclass:: ImagePyramid
 .. autoclass:: OctaveImagePyramid
+  :show-inheritance:
 
 
 Pyramid level
 -------------
 
 .. autoclass:: PyramidLevel
+  :members: resize_image, resize_guide

--- a/pystiche/image/transforms/functional/_resize.py
+++ b/pystiche/image/transforms/functional/_resize.py
@@ -25,6 +25,9 @@ def resize(
     aspect_ratio: Optional[float] = None,
     interpolation_mode: str = "bilinear",
 ) -> torch.Tensor:
+    r"""Resize an image as specified. See :class:`~pystiche.image.transforms.Resize`
+    for details.
+    """
     if aspect_ratio is None:
         aspect_ratio = extract_aspect_ratio(image)
 

--- a/pystiche/image/transforms/resize.py
+++ b/pystiche/image/transforms/resize.py
@@ -11,6 +11,20 @@ __all__ = ["Resize", "Rescale"]
 
 
 class Resize(Transform):
+    r"""Resize an image as specified
+
+    Args:
+        size: Size of the output. If ``int``, ``edge`` is used to determine the image
+            size.
+        edge: Corresponding edge if ``size`` is an edge size. Can be ``"short"``,
+            ``"long"``, ``"vert"``, or ``"horz"``. Defaults to ``"short"``.
+        aspect_ratio: Optional aspect ratio. If ``None`` the aspect ratio of ``image``
+            is used. Defaults to ``None``.
+        interpolation_mode: Interpolation mode used to resize ``image``. Can be
+            ``"nearest"``, ``"bilinear"``, ``"bicubic"``, or ``"area"``. Defaults to
+            ``"bilinear"``.
+    """
+
     def __init__(
         self,
         size: Union[int, Tuple[int, int]],

--- a/pystiche/pyramid/level.py
+++ b/pystiche/pyramid/level.py
@@ -10,6 +10,16 @@ __all__ = ["PyramidLevel"]
 
 
 class PyramidLevel(ComplexObject):
+    r"""Level with an :class:`pystiche.pyramid.ImagePyramid`. If iterated on, yields
+    the step beginning at 1 and ending in ``num_steps``.
+
+    Args:
+        edge_size: Edge size.
+        num_steps: Number of steps.
+        edge: Corresponding edge to the edge size. Can be ``"short"`` or
+            ``"long"``.
+    """
+
     def __init__(self, edge_size: int, num_steps: int, edge: str) -> None:
         self.edge_size = edge_size
         self.num_steps = num_steps
@@ -38,6 +48,22 @@ class PyramidLevel(ComplexObject):
         aspect_ratio: Optional[float] = None,
         interpolation_mode: str = "bilinear",
     ) -> torch.Tensor:
+        r"""Resize an image to the ``edge_size`` on the corresponding ``edge`` of the
+        :class:`PyramidLevel`.
+
+        Args:
+            image: Image to be resized.
+            aspect_ratio: Optional aspect ratio of the output. If ``None``, the aspect
+                ratio of ``image`` is used. Defaults to ``None``.
+            interpolation_mode: Interpolation mode used to resize ``image``. Defaults
+                to ``"bilinear"``.
+
+        .. warning::
+
+            The resizing is performed without gradient calculation. Do **not** use this
+            if image needs a gradient. If that is the case use
+            :class:`pystiche.image.transforms.Resize` instead.
+        """
         return self._resize(image, aspect_ratio, interpolation_mode)
 
     def resize_guide(
@@ -46,6 +72,16 @@ class PyramidLevel(ComplexObject):
         aspect_ratio: Optional[float] = None,
         interpolation_mode: str = "nearest",
     ) -> torch.Tensor:
+        r"""Resize a guide to the ``edge_size`` on the corresponding ``edge`` of the
+        :class:`PyramidLevel`.
+
+        Args:
+            guide: Guide to be resized.
+            aspect_ratio: Optional aspect ratio of the output. If ``None``, the aspect
+                ratio of ``guide`` is used. Defaults to ``None``.
+            interpolation_mode: Interpolation mode used to resize ``image``. Defaults
+                to ``"nearest"``.
+        """
         return self._resize(guide, aspect_ratio, interpolation_mode)
 
     def __iter__(self) -> Iterator[int]:

--- a/pystiche/pyramid/pyramid.py
+++ b/pystiche/pyramid/pyramid.py
@@ -24,6 +24,26 @@ __all__ = ["ImagePyramid", "OctaveImagePyramid"]
 
 
 class ImagePyramid(ComplexObject):
+    r"""Image pyramid for a coarse-to-fine optimization on different levels. If
+    iterated on yields :class:`~pystiche.pyramid.PyramidLevel` s and handles the
+    resizing of all set images and guides of ``resize_targets``.
+
+    Args:
+        edge_sizes: Edge sizes for each level.
+        num_steps: Number of steps for each level. If sequence of ``int`` its length
+            has to match the length of ``edge_sizes``.
+        edge: Corresponding edge to the edge size for each level. Can be ``"short"`` or
+            ``"long"``. If sequence of ``str`` its length has to match the length of
+            ``edge_sizes``. Defaults to ``"short"``.
+        interpolation_mode: Interpolation mode used for the resizing of the images.
+            Defaults to ``"bilinear"``.
+
+            .. note::
+                For the resizing of guides ``"nearest"`` is used regardless of the
+                ``interpolation_mode``.
+        resize_targets: Targets for resizing of set images and guides during iteration.
+    """
+
     def __init__(
         self,
         edge_sizes: Sequence[int],
@@ -117,13 +137,31 @@ class ImagePyramid(ComplexObject):
 
 
 class OctaveImagePyramid(ImagePyramid):
+    r"""Image pyramid that comprises levels spaced by a factor of two.
+
+    Args:
+        max_edge_size: Maximum edge size.
+        num_steps: Number of steps for each level.
+
+            .. note::
+                If ``num_steps`` is specified as sequence of ``int``s, you should also
+                specify ``num_levels`` to match the lengths
+        num_levels: Optional number of levels. If ``None``, the number is determined by
+            the number of steps of factor two between ``max_edge_size`` and
+            ``min_edge_size``.
+        min_edge_size: Minimum edge size for the automatic calculation of
+            ``num_levels``.
+        image_pyramid_kwargs: Additional options. See
+            :class:`~pystiche.pyramid.ImagePyramid` for details.
+    """
+
     def __init__(
         self,
         max_edge_size: int,
         num_steps: Union[int, Sequence[int]],
         num_levels: Optional[int] = None,
         min_edge_size: int = 64,
-        **kwargs: Any,
+        **image_pyramid_kwargs: Any,
     ) -> None:
         if num_levels is None:
             num_levels = int(np.floor(np.log2(max_edge_size / min_edge_size))) + 1
@@ -132,4 +170,4 @@ class OctaveImagePyramid(ImagePyramid):
             round(max_edge_size / (2.0 ** ((num_levels - 1) - level)))
             for level in range(num_levels)
         ]
-        super().__init__(edge_sizes, num_steps, **kwargs)
+        super().__init__(edge_sizes, num_steps, **image_pyramid_kwargs)


### PR DESCRIPTION
This also add documentation for `pystiche.image.transforms.Resize` and `pystiche.image.transforms.functional.resize` since they are referenced from the docstrings of `pystiche.pyramid`.