### PR TITLE
fix isort pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 4.3.21
     hooks:
       - id: isort
-        args: [--check-only]
+        args: [--filter-files, --check-only]
         additional_dependencies: [toml]
   - repo: https://github.com/psf/black
     rev: stable


### PR DESCRIPTION
Without the `--filter-files` option `isort` gives a higher priority to files passed directly to it than to the configuration. During the pre-commit hook the the diff files are passed to `isort` which caused it to fail. See pre-commit/pre-commit/issues/1495 for details.