### PR TITLE
bump sphinx-gallery minimum version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,6 @@
 # -- Imports ---------------------------------------------------------------------------
 
 import os
-import re
 import shutil
 import warnings
 from datetime import datetime
@@ -125,19 +124,6 @@ if download_gallery:
         pass
     shutil.unpack_archive(file, extract_dir=".")
     os.remove(file)
-
-    # This is workaround for a bug in sphinx-gallery that replaces absolute with
-    # relative paths. See https://github.com/pmeier/pystiche/pull/325 for details.
-    index_file = path.join("galleries", "examples", "index.rst")
-    with open(index_file, "r") as fh:
-        content = fh.read()
-    content = re.sub(
-        r"(?P<file>examples_(python|jupyter)\.zip) <[\w/.]+>",
-        r"\g<file> <\g<file>>",
-        content,
-    )
-    with open(index_file, "w") as fh:
-        fh.write(content)
 
     extensions.remove("sphinx_gallery.gen_gallery")
     extensions.append("sphinx_gallery.load_style")

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,0 +1,8 @@
+sphinx >= 2.1, < 3
+sphinxcontrib-bibtex
+sphinx_autodoc_typehints
+sphinx-gallery>=0.8
+# Additional sphinx-gallery dependencies
+# https://sphinx-gallery.github.io/stable/index.html#install-via-pip
+matplotlib
+sphinx_rtd_theme

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,8 +1,0 @@
-sphinx >= 2.1, < 3
-sphinxcontrib-bibtex
-sphinx_autodoc_typehints
-sphinx-gallery>=0.8
-# Additional sphinx-gallery dependencies
-# https://sphinx-gallery.github.io/stable/index.html#install-via-pip
-matplotlib
-sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ commands =
 
 [sphinx-gallery]
 deps =
-  sphinx-gallery>=0.7.0
+  sphinx-gallery>=0.8
   # Additional sphinx-gallery dependencies
   # https://sphinx-gallery.github.io/stable/index.html#install-via-pip
   matplotlib


### PR DESCRIPTION
Fixes #320 and reverts the workaround from #325. 

**DO NOT MERGE** until `sphinx-gallery>=0.8` is released.