### PR TITLE
fix bug in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,9 @@ def get_version():
     __version__ += "+dev"
 
     git = Git()
-    if not git.is_available() and not git.is_repo(PROJECT_ROOT):
+    if not (git.is_available() and git.is_repo(PROJECT_ROOT)):
         return __version__
+
     __version__ += f".{git.hash(PROJECT_ROOT)}"
 
     if not git.is_dirty(PROJECT_ROOT):


### PR DESCRIPTION
`git` has to be available **and** the install root has to be a git repository in order to add the current hash