### PR TITLE
Bump PyTorch versions

### DIFF
--- a/pystiche/core/_modules.py
+++ b/pystiche/core/_modules.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable, Optional, Sequence, Tuple
+from typing import Dict, Iterable, Optional, Sequence, Tuple, cast
 
 import torch
 from torch import nn
@@ -58,7 +58,7 @@ class Module(nn.Module, ComplexObject):
         Returns:
             Native torch representation.
         """
-        return nn.Module.__repr__(self)
+        return cast(str, nn.Module.__repr__(self))
 
     def extra_repr(self) -> str:
         return ", ".join([f"{key}={value}" for key, value in self.properties().items()])

--- a/pystiche/enc/multi_layer_encoder.py
+++ b/pystiche/enc/multi_layer_encoder.py
@@ -33,7 +33,7 @@ class MultiLayerEncoder(pystiche.Module):
         self._storage: Dict[Tuple[str, pystiche.TensorKey], torch.Tensor] = dict()
 
         # TODO: remove this?
-        self.requires_grad_(False)  # type: ignore[operator]
+        self.requires_grad_(False)
         self.eval()
 
     def children_names(self) -> Iterator[str]:

--- a/pystiche/image/transforms/functional/_motif.py
+++ b/pystiche/image/transforms/functional/_motif.py
@@ -169,7 +169,7 @@ def _calculate_full_bounding_box_size(vertices: torch.Tensor) -> Tuple[int, int]
     # values field is returned.
     # https://pytorch.org/docs/stable/torch.html#torch.max
     # This is not reflected in the type hints.
-    coords = cast(torch.Tensor, torch.max(torch.abs(vertices), 1).values)  # type: ignore[attr-defined]
+    coords = torch.max(torch.abs(vertices), 1).values
     return cast(
         Tuple[int, int],
         tuple(reversed(torch.ceil(2.0 * coords).to(torch.int).tolist())),

--- a/pystiche/optim/optim.py
+++ b/pystiche/optim/optim.py
@@ -21,7 +21,7 @@ from .log import (
 )
 
 
-def default_image_optimizer(input_image: torch.Tensor) -> optim.LBFGS:  # type: ignore[name-defined]
+def default_image_optimizer(input_image: torch.Tensor) -> optim.LBFGS:
     r"""
     Args:
         input_image: Image to be optimized.
@@ -30,7 +30,7 @@ def default_image_optimizer(input_image: torch.Tensor) -> optim.LBFGS:  # type: 
         :class:`torch.optim.LBFGS` optimizer with a learning rate of ``1.0``. The
         pixels of ``input_image`` are set as optimization parameters.
     """
-    return optim.LBFGS([input_image.requires_grad_(True)], lr=1.0, max_iter=1)  # type: ignore[attr-defined]
+    return optim.LBFGS([input_image.requires_grad_(True)], lr=1.0, max_iter=1)
 
 
 def default_image_optim_loop(

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,8 @@ python_requires = >=3.6
 # Remember to re-run docs/generate_requirements_rtd.py if you change the install
 # requirements
 install_requires =
-    torch>=1.5.0
-    torchvision>=0.6.0
+    torch>=1.6.0
+    torchvision>=0.7.0
     pillow
     numpy
     requests

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -435,16 +435,26 @@ class TestOptim(PysticheTestCase):
         for actual, desired in zip(actuals, desireds):
             self.assertTensorAlmostEqual(actual, desired)
 
+    def make_torch_ge_1_6_compatible(self, image_loader, criterion):
+        image_loader.generator = None
+
+        for module in criterion.modules():
+            module._non_persistent_buffers_set = set()
+
     @skip_if_py38
     def test_default_transformer_optim_loop(self):
         asset = self.load_asset(path.join("optim", "default_transformer_optim_loop"))
 
+        image_loader = asset.input.image_loader
+        criterion = asset.input.criterion
+        self.make_torch_ge_1_6_compatible(image_loader, criterion)
+
         transformer = asset.input.transformer
         optimizer = asset.params.get_optimizer(transformer)
         transformer = optim.default_transformer_optim_loop(
-            asset.input.image_loader,
+            image_loader,
             transformer,
-            asset.input.criterion,
+            criterion,
             asset.input.criterion_update_fn,
             optimizer=optimizer,
             quiet=True,
@@ -459,6 +469,9 @@ class TestOptim(PysticheTestCase):
         asset = self.load_asset(path.join("optim", "default_transformer_optim_loop"))
 
         image_loader = asset.input.image_loader
+        criterion = asset.input.criterion
+        self.make_torch_ge_1_6_compatible(image_loader, criterion)
+
         optim_logger = optim.OptimLogger()
         log_fn = optim.default_transformer_optim_log_fn(
             optim_logger, len(image_loader), log_freq=1
@@ -468,7 +481,7 @@ class TestOptim(PysticheTestCase):
             optim.default_transformer_optim_loop(
                 image_loader,
                 asset.input.transformer,
-                asset.input.criterion,
+                criterion,
                 asset.input.criterion_update_fn,
                 logger=optim_logger,
                 log_fn=log_fn,
@@ -480,13 +493,17 @@ class TestOptim(PysticheTestCase):
             path.join("optim", "default_transformer_epoch_optim_loop")
         )
 
+        image_loader = asset.input.image_loader
+        criterion = asset.input.criterion
+        self.make_torch_ge_1_6_compatible(image_loader, criterion)
+
         transformer = asset.input.transformer
         optimizer = asset.params.get_optimizer(transformer)
         lr_scheduler = asset.params.get_lr_scheduler(optimizer)
         transformer = optim.default_transformer_epoch_optim_loop(
-            asset.input.image_loader,
+            image_loader,
             transformer,
-            asset.input.criterion,
+            criterion,
             asset.input.criterion_update_fn,
             asset.input.epochs,
             optimizer=optimizer,
@@ -505,6 +522,9 @@ class TestOptim(PysticheTestCase):
         )
 
         image_loader = asset.input.image_loader
+        criterion = asset.input.criterion
+        self.make_torch_ge_1_6_compatible(image_loader, criterion)
+
         log_freq = len(image_loader) + 1
         optim_logger = optim.OptimLogger()
         log_fn = optim.default_transformer_optim_log_fn(
@@ -513,9 +533,9 @@ class TestOptim(PysticheTestCase):
 
         with self.assertLogs(optim_logger.logger, "INFO"):
             optim.default_transformer_epoch_optim_loop(
-                asset.input.image_loader,
+                image_loader,
                 asset.input.transformer,
-                asset.input.criterion,
+                criterion,
                 asset.input.criterion_update_fn,
                 asset.input.epochs,
                 logger=optim_logger,

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -436,6 +436,7 @@ class TestOptim(PysticheTestCase):
             self.assertTensorAlmostEqual(actual, desired)
 
     def make_torch_ge_1_6_compatible(self, image_loader, criterion):
+        # See https://github.com/pmeier/pystiche/pull/348 for a discussion of this
         image_loader.generator = None
 
         for module in criterion.modules():


### PR DESCRIPTION
This bump makes it necessary to introduce a `make_torch_ge_1_6_compatible` into the tests that adds missing attributes to the stored `DataLoader`s and `Module`s. I expect similar errors in the future. Thus, we need to overthink the test concept in the (near) future.