### PR TITLE
temporarily disable latex doc builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,8 +58,8 @@ jobs:
           name: html
           path: docs/build/html
 
-      - name: Upload latex build
-        uses: actions/upload-artifact@v2
-        with:
-          name: latex
-          path: docs/build/latex/pystiche.pdf
+#      - name: Upload latex build
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: latex
+#          path: docs/build/latex/pystiche.pdf

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,14 @@
+#See link below for available options
+#https://docs.readthedocs.io/en/stable/config-file/
+
 version: 2
 
 sphinx:
   configuration: docs/source/conf.py
 
-formats: all
+formats:
+  - htmlzip
+  - epub
 
 python:
   version: 3.6

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ deps =
 changedir = docs
 commands =
   sphinx-build -M html source build
-  sphinx-build -M latexpdf source build
+;  sphinx-build -M latexpdf source build
 
 [testenv:publishable]
 whitelist_externals =


### PR DESCRIPTION
As of this morning, the `docs` workflow as well as the RTD build fail with 

```
! TeX capacity exceeded, sorry [main memory size=5000000].
[...]
!  ==> Fatal error occurred, no output PDF file produced!
```

I do not yet know was causes this. I've reported this in https://github.com/readthedocs/readthedocs.org/issues/7344.