### PR TITLE
Re-enable Latex Builds for testing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,8 +58,8 @@ jobs:
           name: html
           path: docs/build/html
 
-#      - name: Upload latex build
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: latex
-#          path: docs/build/latex/pystiche.pdf
+      - name: Upload latex build
+        uses: actions/upload-artifact@v2
+        with:
+          name: latex
+          path: docs/build/latex/pystiche.pdf

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,14 +1,9 @@
-#See link below for available options
-#https://docs.readthedocs.io/en/stable/config-file/
-
 version: 2
 
 sphinx:
   configuration: docs/source/conf.py
 
-formats:
-  - htmlzip
-  - epub
+formats: all
 
 python:
   version: 3.6

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ deps =
 changedir = docs
 commands =
   sphinx-build -M html source build
-;  sphinx-build -M latexpdf source build
+  sphinx-build -M latexpdf source build
 
 [testenv:publishable]
 whitelist_externals =


### PR DESCRIPTION
Revert "temporarily disable latex doc builds (#355)". This reverts commit 30039013fb452a5abed7dd4ff637c06d0ae98960.
