### PR TITLE
switch versioning scheme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # https://github.com/pypa/setuptools_scm/#configuration-parameters
 
 write_to = "pystiche/_version.py"
-version_scheme = "guess-next-dev"
+version_scheme = "release-branch-semver"
 local_scheme = "node-and-timestamp"
 
 [tool.isort]


### PR DESCRIPTION
Switch from `guess-next-dev` to `release-branch-semver`. The former guesses the next version by incrementing the patch number while the latter increments the minor version.