### PR TITLE
Add smoke tests for galleries

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,12 +53,41 @@ jobs:
         run: pip install -r requirements-dev.txt
 
       - name: Create environment
-        run: tox --notest
+        run: tox -e tests-integration --notest
 
       - name: Run tests
-        run: tox -- --skip-large-download
+        run: tox -e tests-integration -- --skip-large-download
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1.0.12
         with:
           env_vars: OS,PYTHON
+
+  galleries:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Upgrade or install additional system packages
+        run: pip install --upgrade pip setuptools virtualenv wheel
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install dev requirements
+        run: pip install -r requirements-dev.txt
+
+      - name: Create environment
+        run: tox -e tests-galleries --notest
+
+      - name: Run tests
+        run: tox -e tests-galleries

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,8 @@ run_by_ci = (
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-PROJECT_ROOT = path.abspath(path.join(path.dirname(__file__), "..", ".."))
+HERE = path.dirname(__file__)
+PROJECT_ROOT = path.abspath(path.join(HERE, "..", ".."))
 
 
 # -- Project information ---------------------------------------------------------------
@@ -215,7 +216,7 @@ html_theme = "sphinx_rtd_theme"
 
 # -- Latex / Mathjax config ------------------------------------------------------------
 
-with open("custom_cmds.tex", "r") as fh:
+with open(path.join(HERE, "custom_cmds.tex"), "r") as fh:
     custom_cmds = fh.read()
 
 latex_elements = {"preamble": custom_cmds}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ filter_files = true
 extra_standard_library = ["importlib_metadata"]
 known_third_party = [
   "dill",
+  "igittigitt",
   "light-the-torch",
   "matplotlib",
   "numpy",

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,5 +5,4 @@ markers =
   slow
   slow_if_cuda_not_available
   flaky
-testpaths = tests/
 addopts = -ra

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,12 +4,20 @@ import pytest
 
 from torch import nn
 
+import pystiche
+
 from . import assets, utils
 
 
 @pytest.fixture(scope="session", autouse=True)
 def watch_project_dir():
     with utils.watch_dir("."):
+        yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def watch_pystiche_home():
+    with utils.watch_dir(pystiche.home()):
         yield
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,7 +4,13 @@ import pytest
 
 from torch import nn
 
-from . import assets
+from . import assets, utils
+
+
+@pytest.fixture(scope="session", autouse=True)
+def watch_project_dir():
+    with utils.watch_dir("."):
+        yield
 
 
 @pytest.fixture(scope="session")

--- a/tests/galleries/__init__.py
+++ b/tests/galleries/__init__.py
@@ -1,0 +1,15 @@
+def maybe_update(dct, key, val):
+    if key not in dct:
+        dct[key] = val
+
+
+def exec_file(file, globals=None, locals=None):
+    if globals is None:
+        globals = {}
+    maybe_update(globals, "__file__", file)
+    maybe_update(globals, "__name__", "__main__")
+
+    with open(file, "r") as fh:
+        exec(fh.read(), globals, locals)
+
+    return globals, locals

--- a/tests/galleries/conftest.py
+++ b/tests/galleries/conftest.py
@@ -2,7 +2,6 @@ import os
 import re
 from os import path
 
-import matplotlib.pyplot as plt
 import pytest
 
 from . import exec_file
@@ -48,9 +47,6 @@ def sphinx_gallery_scripts(sphinx_gallery_config):
 @pytest.fixture(scope="package", autouse=True)
 def patch_multi_layer_encoder_load_weights(package_mocker):
     mocks.patch_multi_layer_encoder_load_weights(mocker=package_mocker)
-
-
-plt.show()
 
 
 @pytest.fixture(scope="package", autouse=True)

--- a/tests/galleries/conftest.py
+++ b/tests/galleries/conftest.py
@@ -1,0 +1,82 @@
+import os
+import re
+from os import path
+
+import matplotlib.pyplot as plt
+import pytest
+
+from . import exec_file
+from tests import mocks, utils
+
+SPHINX_CONFIG_FILE = path.abspath(
+    path.join(path.dirname(__file__), "..", "..", "docs", "source", "conf.py")
+)
+
+
+@pytest.fixture(scope="package")
+def sphinx_config():
+    config, _ = exec_file(SPHINX_CONFIG_FILE)
+    return config
+
+
+@pytest.fixture(scope="package")
+def sphinx_gallery_config(sphinx_config):
+    return sphinx_config["sphinx_gallery_conf"]
+
+
+@pytest.fixture(scope="package")
+def sphinx_gallery_scripts(sphinx_gallery_config):
+    file_pattern = re.compile(
+        sphinx_gallery_config["filename_pattern"][1:] + r"[^.]*.py$"
+    )
+
+    dirs = set()
+    scripts = []
+    for root, _, files in os.walk(sphinx_gallery_config["examples_dirs"]):
+        for file in files:
+            match = file_pattern.match(file)
+            if match is None:
+                continue
+
+            dirs.add(root)
+            scripts.append(path.splitext(file)[0])
+
+    with utils.temp_add_to_sys_path(*dirs, root=None):
+        yield tuple(scripts)
+
+
+@pytest.fixture(scope="package", autouse=True)
+def patch_multi_layer_encoder_load_weights(package_mocker):
+    mocks.patch_multi_layer_encoder_load_weights(mocker=package_mocker)
+
+
+plt.show()
+
+
+@pytest.fixture(scope="package", autouse=True)
+def patch_matplotlib_figures(package_mocker):
+    package_mocker.patch(mocks.make_mock_target("image", "show_image"))
+    package_mocker.patch(
+        mocks.make_mock_target("pyplot", "new_figure_manager", pkg="matplotlib")
+    )
+
+
+@pytest.fixture(autouse=True)
+def patch_optim_loops(mocker):
+    def optim_loop_side_effect(input, *args, **kwargs):
+        return input
+
+    for name in (
+        "default_image_optim_loop",
+        "default_image_pyramid_optim_loop",
+        "default_transformer_optim_loop",
+        "default_transformer_epoch_optim_loop",
+    ):
+        mocker.patch(
+            mocks.make_mock_target("optim", name), side_effect=optim_loop_side_effect
+        )
+
+    # Since the beginner example "NST without pystiche" does not use a builtin
+    # optimization loop we are patching the optimizer. The actual computation happens
+    # inside a closure. Thus, the loop will run, albeit with an almost empty body.
+    mocker.patch(mocks.make_mock_target("optim", "LBFGS", pkg="torch"))

--- a/tests/galleries/test_galleries.py
+++ b/tests/galleries/test_galleries.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.mark.slow
+def test_gallery_scripts_smoke(subtests, sphinx_gallery_scripts):
+    for script in sphinx_gallery_scripts:
+        with subtests.test(script):
+            __import__(script)

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,0 +1,44 @@
+import os
+import unittest.mock
+from distutils import dir_util
+
+import pystiche
+
+__all__ = [
+    "make_mock_target",
+    "patch_multi_layer_encoder_load_weights",
+    "patch_home",
+]
+
+DEFAULT_MOCKER = unittest.mock
+
+
+def make_mock_target(*args, pkg="pystiche"):
+    return ".".join((pkg, *args))
+
+
+_MULTI_LAYER_ENCODER_LOAD_WEIGHTS_TARGETS = {
+    "vgg": make_mock_target(
+        "enc", "models", "vgg", "VGGMultiLayerEncoder", "_load_weights"
+    ),
+    "alexnet": make_mock_target(
+        "enc", "models", "alexnet", "AlexNetMultiLayerEncoder", "_load_weights",
+    ),
+}
+
+
+def patch_multi_layer_encoder_load_weights(models=None, mocker=DEFAULT_MOCKER):
+    if models is None:
+        models = _MULTI_LAYER_ENCODER_LOAD_WEIGHTS_TARGETS.keys()
+
+    return {
+        model: mocker.patch(_MULTI_LAYER_ENCODER_LOAD_WEIGHTS_TARGETS[model])
+        for model in models
+    }
+
+
+def patch_home(home, copy=True, mocker=DEFAULT_MOCKER):
+    if copy:
+        dir_util.copy_tree(pystiche.home(), home)
+
+    return mocker.patch.dict(os.environ, values={"PYSTICHE_HOME": home})

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,17 +1,27 @@
 import contextlib
+import itertools
 import os
 import shutil
 import stat
+import sys
 import tempfile
+from distutils import dir_util
+from os import path
 
 import pytest
+from gitignore_parser import parse_gitignore
 
 import torch
 
 __all__ = [
     "get_tmp_dir",
     "skip_if_cuda_not_available",
+    "watch_dir",
+    "temp_add_to_sys_path",
 ]
+
+
+PROJECT_ROOT = path.abspath(path.join(path.dirname(__file__), ".."))
 
 
 # Adapted from
@@ -47,3 +57,96 @@ def get_tmp_dir(**mkdtemp_kwargs):
 skip_if_cuda_not_available = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="CUDA is not available."
 )
+
+
+def walk_git_project(*args, **kwargs):
+    matches = parse_gitignore(path.join(PROJECT_ROOT, ".gitignore"))
+    for root, dirs, files in os.walk(*args, **kwargs):
+
+        if matches(root):
+            continue
+
+        ignored_dirs = [dir for dir in dirs if matches(dir) or dir == ".git"]
+        # remove them in-place to avoid further exploration
+        for dir in ignored_dirs:
+            dirs.remove(dir)
+
+        files = [file for file in files if not matches(file)]
+        yield root, dirs, files
+
+
+def _find_dirs_and_files(top, honor_gitignore=True):
+    walk = walk_git_project if honor_gitignore else os.walk
+
+    dirs = set()
+    files = set()
+    for root, rel_dirs, rel_files in walk(top):
+        dirs.update(path.join(root, rel_dir) for rel_dir in rel_dirs)
+        files.update(path.join(root, rel_file) for rel_file in rel_files)
+    return dirs, files
+
+
+def _rel_to_abs_path(rel_path, root):
+    if root is None:
+        return rel_path
+
+    return path.join(root, rel_path)
+
+
+@contextlib.contextmanager
+def watch_dir(
+    rel_path,
+    root=PROJECT_ROOT,
+    error_on_diff=False,
+    remove_diff=None,
+    honor_gitignore=True,
+):
+    abs_path = _rel_to_abs_path(rel_path, root)
+
+    if remove_diff is None:
+        remove_diff = not error_on_diff
+
+    old_dirs, old_files = _find_dirs_and_files(
+        abs_path, honor_gitignore=honor_gitignore
+    )
+    try:
+        yield
+    finally:
+        new_dirs, new_files = _find_dirs_and_files(
+            abs_path, honor_gitignore=honor_gitignore
+        )
+
+        diff_dirs = new_dirs - old_dirs
+        diff_files = new_files - old_files
+
+        if not (diff_dirs or diff_files):
+            return
+
+        if remove_diff:
+            for dir in diff_dirs:
+                dir_util.remove_tree(dir)
+
+            for file in diff_files:
+                try:
+                    os.remove(file)
+                except FileNotFoundError:
+                    # file might have been already removed with dir removal
+                    pass
+
+        if error_on_diff:
+            msg = "The following directories and files were added:\n\n" "\n".join(
+                itertools.chain(diff_dirs, diff_files)
+            )
+            raise pytest.UsageError(msg)
+
+
+@contextlib.contextmanager
+def temp_add_to_sys_path(*rel_paths, root=PROJECT_ROOT):
+    abs_paths = [_rel_to_abs_path(rel_path, root) for rel_path in rel_paths]
+    for abs_path in abs_paths:
+        sys.path.insert(0, abs_path)
+    try:
+        yield
+    finally:
+        for abs_path in abs_paths:
+            sys.path.remove(abs_path)

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
   pytest-subtests >= 0.3.2
   pytest-cov
   pytest-mock >= 3.1
+  dill
   gitignore_parser
 commands = pytest -c pytest.ini --durations=25
 
@@ -26,7 +27,6 @@ deps =
   pillow_affine
   pyimagetest >= 0.3
   pillow_affine
-  dill
   # TODO: move to a released version
   git+https://github.com/pmeier/pytorch_testing_utils
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
   pytest-cov
   pytest-mock >= 3.1
   dill
-  gitignore_parser
+  igittigitt
 commands = pytest -c pytest.ini --durations=25
 
 [testenv:tests-integration]

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ deps =
   pytest-subtests >= 0.3.2
   pytest-cov
   pytest-mock >= 3.1
-  dill
   gitignore_parser
 commands = pytest -c pytest.ini --durations=25
 
@@ -27,6 +26,7 @@ deps =
   pillow_affine
   pyimagetest >= 0.3
   pillow_affine
+  dill
   # TODO: move to a released version
   git+https://github.com/pmeier/pytorch_testing_utils
 commands =
@@ -34,19 +34,18 @@ commands =
     --cov=pystiche \
     --cov-report=xml \
     --cov-config=.coveragerc \
-    {posargs:tests/integration}
+    tests/integration \
+    {posargs}
 
 [testenv:tests-galleries]
 deps =
   {[tests-common]deps}
   importlib_metadata
-  sphinx-gallery>=0.7.0
-  # Additional sphinx-gallery dependencies
-  # https://sphinx-gallery.github.io/stable/index.html#install-via-pip
-  matplotlib
+  {[sphinx-gallery]deps}
 commands =
   {[tests-common]commands} \
-    {posargs:tests/galleries}
+    tests/galleries \
+    {posargs}
 
 [testenv:lint-style]
 whitelist_externals =
@@ -63,6 +62,14 @@ deps =
 commands =
   mypy --config-file=mypy.ini
 
+[sphinx-gallery]
+deps =
+  sphinx-gallery>=0.7.0
+  # Additional sphinx-gallery dependencies
+  # https://sphinx-gallery.github.io/stable/index.html#install-via-pip
+  matplotlib
+
+
 [docs-common]
 passenv =
   HOME
@@ -77,10 +84,7 @@ deps =
   importlib-metadata
   sphinxcontrib-bibtex
   sphinx_autodoc_typehints >= 1.11
-  sphinx-gallery>=0.7.0
-  # Additional sphinx-gallery dependencies
-  # https://sphinx-gallery.github.io/stable/index.html#install-via-pip
-  matplotlib
+  {[sphinx-gallery]deps}
   sphinx_rtd_theme
 changedir = docs
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,8 @@ deps =
   pytest-subtests >= 0.3.2
   pytest-cov
   pytest-mock >= 3.1
-    dill
+  dill
+  gitignore_parser
 commands = pytest -c pytest.ini --durations=25
 
 [testenv:tests-integration]
@@ -26,7 +27,6 @@ deps =
   pillow_affine
   pyimagetest >= 0.3
   pillow_affine
-  dill
   # TODO: move to a released version
   git+https://github.com/pmeier/pytorch_testing_utils
 commands =
@@ -44,7 +44,6 @@ deps =
   # Additional sphinx-gallery dependencies
   # https://sphinx-gallery.github.io/stable/index.html#install-via-pip
   matplotlib
-  gitignore_parser
 commands =
   {[tests-common]commands} \
     {posargs:tests/galleries}

--- a/tox.ini
+++ b/tox.ini
@@ -5,29 +5,49 @@
 requires =
   tox-factor
   tox-ltt
-envlist = tests
+envlist = tests-{integration, galleries}
 isolated_build = True
 
-[testenv:tests]
-passenv =
-  GITHUB_ACTIONS
+[tests-common]
 deps =
   pytest >= 6
-  pyimagetest >= 0.3
-  pillow_affine
-  dill
   pytest-subtests >= 0.3.2
   pytest-cov
   pytest-mock >= 3.1
+    dill
+commands = pytest -c pytest.ini --durations=25
+
+[testenv:tests-integration]
+passenv =
+  GITHUB_ACTIONS
+deps =
+  {[tests-common]deps}
+  pyimagetest >= 0.3
+  pillow_affine
+  pyimagetest >= 0.3
+  pillow_affine
+  dill
   # TODO: move to a released version
   git+https://github.com/pmeier/pytorch_testing_utils
 commands =
-  pytest \
-    -c pytest.ini \
+  {[tests-common]commands} \
     --cov=pystiche \
     --cov-report=xml \
     --cov-config=.coveragerc \
-    {posargs}
+    {posargs:tests/integration}
+
+[testenv:tests-galleries]
+deps =
+  {[tests-common]deps}
+  importlib_metadata
+  sphinx-gallery>=0.7.0
+  # Additional sphinx-gallery dependencies
+  # https://sphinx-gallery.github.io/stable/index.html#install-via-pip
+  matplotlib
+  gitignore_parser
+commands =
+  {[tests-common]commands} \
+    {posargs:tests/galleries}
 
 [testenv:lint-style]
 whitelist_externals =


### PR DESCRIPTION
Since we cannot build the galleries in CI due to computation costs, this adds smoke test that run each example while the computation intensive parts are mocked out.