### PR TITLE
make package importable without installation

### DIFF
--- a/pystiche/__init__.py
+++ b/pystiche/__init__.py
@@ -1,4 +1,7 @@
-from ._version import version as __version__  # type: ignore[import]
+try:
+    from ._version import version as __version__  # type: ignore[import]
+except ImportError:
+    __version__ = "UNKNOWN"
 
 from .core import *
 

--- a/tests/integration/test_package.py
+++ b/tests/integration/test_package.py
@@ -1,7 +1,17 @@
 import importlib
 import pkgutil
+import re
 
-import pystiche as package_under_test
+from tests.mocks import patch_imports
+
+
+def import_package_under_test():
+    import pystiche as package_under_test
+
+    return package_under_test
+
+
+put = import_package_under_test()
 
 
 def test_importability(subtests):
@@ -16,9 +26,7 @@ def test_importability(subtests):
             raise
 
     for finder, name, is_package in pkgutil.walk_packages(
-        path=package_under_test.__path__,
-        prefix=f"{package_under_test.__name__}.",
-        onerror=onerror,
+        path=put.__path__, prefix=f"{put.__name__}.", onerror=onerror,
     ):
         if is_private(name):
             continue
@@ -30,5 +38,35 @@ def test_importability(subtests):
                 onerror(name)
 
 
-def test_version_availability():
-    assert isinstance(package_under_test.__version__, str)
+def test_version_installed():
+    def is_canonical(version):
+        # Copied from
+        # https://www.python.org/dev/peps/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
+        return (
+            re.match(
+                r"^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$",
+                version,
+            )
+            is not None
+        )
+
+    def is_dev(version):
+        match = re.search(r"\+g[\da-f]{7}([.]\d{14})?", version)
+        if match is not None:
+            return is_canonical(version[: match.span()[0]])
+        else:
+            return False
+
+    assert is_canonical(put.__version__) or is_dev(put.__version__)
+
+
+def test_version_not_installed(mocker):
+    def import_error_condition(name, globals, locals, fromlist, level):
+        return name == "_version" and fromlist == ("version",)
+
+    patch_imports(
+        (put.__name__,), import_error_condition=import_error_condition, mocker=mocker
+    )
+
+    reimported_put = import_package_under_test()
+    assert reimported_put.__version__ == "UNKNOWN"

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,4 +1,6 @@
+import builtins
 import os
+import sys
 import unittest.mock
 from distutils import dir_util
 
@@ -6,6 +8,7 @@ import pystiche
 
 __all__ = [
     "make_mock_target",
+    "patch_imports",
     "patch_multi_layer_encoder_load_weights",
     "patch_home",
 ]
@@ -15,6 +18,49 @@ DEFAULT_MOCKER = unittest.mock
 
 def make_mock_target(*args, pkg="pystiche"):
     return ".".join((pkg, *args))
+
+
+def patch_imports(
+    names,
+    clear=True,
+    retain_condition=None,
+    import_error_condition=None,
+    mocker=DEFAULT_MOCKER,
+):
+    if retain_condition is None:
+
+        def retain_condition(name):
+            return not any(name.startswith(name_) for name_ in names)
+
+    if import_error_condition is None:
+
+        def import_error_condition(name, globals, locals, fromlist, level):
+            direct = name in names
+            indirect = fromlist is not None and any(
+                from_ in names for from_ in fromlist
+            )
+            return direct or indirect
+
+    __import__ = builtins.__import__
+
+    def patched_import(name, globals, locals, fromlist, level):
+        if import_error_condition(name, globals, locals, fromlist, level):
+            raise ImportError
+
+        return __import__(name, globals, locals, fromlist, level)
+
+    mocker.patch.object(builtins, "__import__", new=patched_import)
+    if clear:
+        values = {
+            name: module
+            for name, module in sys.modules.items()
+            if retain_condition(name)
+        }
+    else:
+        values = {}
+    mocker.patch.dict(
+        sys.modules, clear=clear, values=values,
+    )
 
 
 _MULTI_LAYER_ENCODER_LOAD_WEIGHTS_TARGETS = {


### PR DESCRIPTION
Without this change `torch.hub.help("pmeier/pystiche", ...)` (or any other hub function) fails, since it doesn't install `pystiche` before loading the models