### PR TITLE
limit black version to 19.10b0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ on:
       - ".github/workflows/lint.yml"
       - "setup.cfg"
       - "pyproject.toml"
+      - ".pre-commit-config.yaml"
 
 jobs:
   style:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: isort
         args: [--settings-path=pyproject.toml]
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: "19.10b0"
     hooks:
       - id: black
         args: [--config=pyproject.toml]


### PR DESCRIPTION
The new release (`>= 20`) broke something with the magic trailing comma.