### PR TITLE
fix Zenodo metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,13 @@
+{
+    "license":"BSD-3-Clause",
+    "creators":[
+        {
+            "name":"Philip Meier",
+            "affiliation":"inIT - Institute Industrial IT, Technische Hochschule Ostwestfalen-Lippe (TH OWL)"
+        },
+        {
+            "name":"Volker Lohweg",
+            "affiliation":"inIT - Institute Industrial IT, Technische Hochschule Ostwestfalen-Lippe (TH OWL)"
+        }
+    ]
+}


### PR DESCRIPTION
Zenodo guesses the release metadata automatically. This PR adds a file that corrects the parts were the guess is not correct (see https://github.com/openjournals/joss-reviews/issues/2761#issuecomment-712301580)