### PR TITLE
disable auto batch size matching for MRF operator

### DIFF
--- a/pystiche/ops/comparison.py
+++ b/pystiche/ops/comparison.py
@@ -269,6 +269,11 @@ class MRFOperator(EncodingComparisonOperator):
             )
         ]
 
+    @staticmethod
+    def _match_batch_sizes(target: torch.Tensor, input: torch.Tensor) -> torch.Tensor:
+        # FIXME
+        return target
+
     def set_target_guide(self, guide: torch.Tensor, recalc_repr: bool = True) -> None:
         # Since the target representation of the MRFOperator possibly comprises
         # scaled or rotated patches, it is not useful to store the target encoding


### PR DESCRIPTION
The auto batch size matching introduced in #432 is not compatible with the current implementation of `ops.MRFOperator`. The reason is that we currently representing the extracted patches in a tensor of shape `B*PxCxHxW` where `P` denotes the number of patches. Thus, if the input and target image do not have the same spatial size, the number of elements in the first dimension, i.e. the batch dimension, will mismatch.

For the future, we should switch to another representation for example `BxPxCxHxW` to avoid this.