### PR TITLE
emit FutureWarning on MLE call and encode

### DIFF
--- a/pystiche/loss/multi_op.py
+++ b/pystiche/loss/multi_op.py
@@ -6,6 +6,7 @@ from torch import nn
 
 import pystiche
 from pystiche import enc, ops
+from pystiche.misc import suppress_future_warnings
 
 __all__ = ["MLEHandler", "MultiOperatorLoss"]
 
@@ -32,8 +33,9 @@ class MLEHandler(pystiche.ComplexObject):
             mle.trim()
 
     def __call__(self, input_image: torch.Tensor) -> "MLEHandler":
-        for mle in self.multi_layer_encoders:
-            mle.encode(input_image)
+        with suppress_future_warnings():
+            for mle in self.multi_layer_encoders:
+                mle.encode(input_image)
         return self
 
     def __enter__(self) -> None:

--- a/pystiche/misc.py
+++ b/pystiche/misc.py
@@ -1,3 +1,4 @@
+import contextlib
 import itertools
 import warnings
 from functools import reduce as _reduce
@@ -8,6 +9,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    Iterator,
     Optional,
     Sequence,
     Tuple,
@@ -34,6 +36,7 @@ __all__ = [
     "get_device",
     "download_file",
     "reduce",
+    "suppress_future_warnings",
 ]
 
 
@@ -278,3 +281,12 @@ def reduce(x: torch.Tensor, reduction: str) -> torch.Tensor:
         return torch.sum(x)
     else:  # reduction == "none":
         return x
+
+
+@contextlib.contextmanager
+def suppress_future_warnings() -> Iterator[None]:
+    warnings.filterwarnings("ignore", category=FutureWarning)
+    try:
+        yield
+    finally:
+        warnings.resetwarnings()

--- a/tests/integration/enc/test_multi_layer_encoder.py
+++ b/tests/integration/enc/test_multi_layer_encoder.py
@@ -245,6 +245,30 @@ def test_MultiLayerEncoder_trim_layers():
             getattr(multi_layer_encoder, name)
 
 
+def test_MultiLayerEncoder_call_future_warning():
+    torch.manual_seed(0)
+    conv = nn.Conv2d(3, 1, 1)
+    input = torch.rand(1, 3, 1, 1)
+
+    modules = (("conv", conv),)
+    multi_layer_encoder = enc.MultiLayerEncoder(modules)
+
+    with pytest.warns(FutureWarning):
+        multi_layer_encoder(input, ("conv",))
+
+
+def test_MultiLayerEncoder_encode_future_warning():
+    torch.manual_seed(0)
+    conv = nn.Conv2d(3, 1, 1)
+    input = torch.rand(1, 3, 1, 1)
+
+    modules = (("conv", conv),)
+    multi_layer_encoder = enc.MultiLayerEncoder(modules)
+
+    with pytest.warns(FutureWarning):
+        multi_layer_encoder.encode(input)
+
+
 def test_SingleLayerEncoder_call():
     torch.manual_seed(0)
     conv = nn.Conv2d(3, 1, 1)


### PR DESCRIPTION
This foreshadows the changes in #435. Since, we only need to emit these warnings if `enc.MultiLayerEncoder` is used directly, they are suppressed if used internally.