### PR TITLE
Deprecate non-batched extract_patchesnd, cosine_similarity, and mrf_loss

### DIFF
--- a/pystiche/core/_utils.py
+++ b/pystiche/core/_utils.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Sequence, Union
 
 import torch
@@ -9,6 +10,18 @@ __all__ = [
     "extract_patches2d",
     "extract_patches3d",
 ]
+
+
+def _warn_output_shape(*dim_names: str) -> None:
+    name = f"extract_patches{len(dim_names)}d"
+    partial_shape = "x".join(dim_names)
+    warnings.warn(
+        f"The output shape of {name} will change in the future. "
+        f"The current shape B*PxCx{partial_shape} will be replaced by "
+        f"BxPxCx{partial_shape} thus adding a dimension. "
+        f"Here, 'P' denotes the number of extracted patches.",
+        FutureWarning,
+    )
 
 
 def _extract_patchesnd(
@@ -29,6 +42,7 @@ def extract_patches1d(
     stride: Union[int, Sequence[int]] = 1,
 ) -> torch.Tensor:
     assert x.dim() == 3
+    _warn_output_shape("L")
     return _extract_patchesnd(x, to_1d_arg(patch_size), to_1d_arg(stride))
 
 
@@ -38,6 +52,7 @@ def extract_patches2d(
     stride: Union[int, Sequence[int]] = 1,
 ) -> torch.Tensor:
     assert x.dim() == 4
+    _warn_output_shape("H", "W")
     return _extract_patchesnd(x, to_2d_arg(patch_size), to_2d_arg(stride))
 
 
@@ -47,4 +62,5 @@ def extract_patches3d(
     stride: Union[int, Sequence[int]] = 1,
 ) -> torch.Tensor:
     assert x.dim() == 5
+    _warn_output_shape("D", "H", "W")
     return _extract_patchesnd(x, to_3d_arg(patch_size), to_3d_arg(stride))

--- a/pystiche/ops/comparison.py
+++ b/pystiche/ops/comparison.py
@@ -8,7 +8,7 @@ import torch
 import pystiche
 from pystiche.enc import Encoder
 from pystiche.image.transforms import Transform, TransformMotifAffinely
-from pystiche.misc import to_2d_arg
+from pystiche.misc import suppress_future_warnings, to_2d_arg
 
 from . import functional as F
 from .op import EncodingComparisonOperator
@@ -300,7 +300,8 @@ class MRFOperator(EncodingComparisonOperator):
         return repr[mask]
 
     def enc_to_repr(self, enc: torch.Tensor, is_guided: bool) -> torch.Tensor:
-        repr = pystiche.extract_patches2d(enc, self.patch_size, self.stride)
+        with suppress_future_warnings():
+            repr = pystiche.extract_patches2d(enc, self.patch_size, self.stride)
         if not is_guided:
             return repr
 

--- a/pystiche/ops/comparison.py
+++ b/pystiche/ops/comparison.py
@@ -342,7 +342,7 @@ class MRFOperator(EncodingComparisonOperator):
         target_repr: torch.Tensor,
         ctx: Optional[torch.Tensor],
     ) -> torch.Tensor:
-        return F.mrf_loss(input_repr, target_repr)
+        return F.mrf_loss(input_repr, target_repr, batched_input=True)
 
     def _properties(self) -> Dict[str, Any]:
         dct = super()._properties()

--- a/pystiche/ops/comparison.py
+++ b/pystiche/ops/comparison.py
@@ -342,7 +342,7 @@ class MRFOperator(EncodingComparisonOperator):
         target_repr: torch.Tensor,
         ctx: Optional[torch.Tensor],
     ) -> torch.Tensor:
-        return F.mrf_loss(input_repr, target_repr, batched_input=True)
+        return F.mrf_loss(input_repr, target_repr, batched_input=False)
 
     def _properties(self) -> Dict[str, Any]:
         dct = super()._properties()

--- a/tests/integration/core/test_math.py
+++ b/tests/integration/core/test_math.py
@@ -1,5 +1,6 @@
 from math import sqrt
 
+import pytest
 import pytorch_testing_utils as ptu
 
 import torch
@@ -84,10 +85,11 @@ def test_cosine_similarity():
     torch.manual_seed(0)
     input = torch.rand(1, 256)
     target = torch.rand(1, 256)
+    eps = 1e-6
 
-    actual = pystiche.cosine_similarity(input, target)
-    expected = F.cosine_similarity(input, target, dim=1).unsqueeze(1)
-    ptu.assert_allclose(actual, expected)
+    actual = pystiche.cosine_similarity(input, target, eps=eps)
+    expected = F.cosine_similarity(input, target, dim=1, eps=eps).unsqueeze(1)
+    ptu.assert_allclose(actual, expected, rtol=1e-6)
 
 
 def test_cosine_similarity_shape():
@@ -96,3 +98,22 @@ def test_cosine_similarity_shape():
     target = torch.rand(2, 3, 4, 5)
 
     assert pystiche.cosine_similarity(input, target).size() == (2, 2)
+
+
+def test_cosine_similarity_future_warning():
+    x1 = torch.empty(1, 2)
+    x2 = torch.empty(1, 2)
+
+    with pytest.warns(FutureWarning):
+        pystiche.cosine_similarity(x1, x2)
+
+
+def test_cosine_similarity_batched_input():
+    torch.manual_seed(0)
+    x1 = torch.rand(2, 1, 256)
+    x2 = torch.rand(2, 1, 256)
+    eps = 1e-6
+
+    actual = pystiche.cosine_similarity(x1, x2, eps=eps, batched_input=True)
+    expected = F.cosine_similarity(x1, x2, dim=2, eps=eps).unsqueeze(2)
+    ptu.assert_allclose(actual, expected, rtol=1e-6)

--- a/tests/integration/core/test_utils.py
+++ b/tests/integration/core/test_utils.py
@@ -1,3 +1,4 @@
+import pytest
 import pytorch_testing_utils as ptu
 
 import torch
@@ -49,3 +50,11 @@ def test_extract_patches1d():
     actual = patches[-1]
     desired = x[-1, :, -patch_size:]
     ptu.assert_allclose(actual, desired)
+
+
+@pytest.mark.parametrize("n", (1, 2, 3))
+def test_extract_patchesnd_future_warning(n):
+    x = torch.empty(1, 1, *[1] * n)
+    with pytest.warns(FutureWarning):
+        fn = getattr(pystiche, f"extract_patches{n}d")
+        fn(x, 1)

--- a/tests/integration/ops/test_functional.py
+++ b/tests/integration/ops/test_functional.py
@@ -1,3 +1,4 @@
+import pytest
 import pytorch_testing_utils as ptu
 
 import torch
@@ -18,6 +19,13 @@ def test_mrf_loss():
     actual = F.mrf_loss(input, target)
     desired = mse_loss(input, torch.stack((rand_patch, rand_patch)))
     ptu.assert_allclose(actual, desired)
+
+
+def test_mrf_loss_future_warning():
+    input = torch.empty(1, 2)
+    target = torch.empty(1, 2)
+    with pytest.warns(FutureWarning):
+        F.mrf_loss(input, target)
 
 
 def test_value_range_loss_zero():


### PR DESCRIPTION
As discussed in #433.