### PR TITLE
make doctest more strict

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -206,6 +206,9 @@ from torch import nn
 
 from pystiche import enc, ops, loss
 import pystiche.ops.functional as F
+
+import warnings
+warnings.filterwarnings("ignore", category=FutureWarning)
 """
 
 # -- Options for HTML output -----------------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,16 +32,8 @@ def get_bool_env_var(name, default=False):
 
 
 run_by_github_actions = get_bool_env_var("GITHUB_ACTIONS")
-run_by_travis_ci = get_bool_env_var("TRAVIS")
-run_by_appveyor = get_bool_env_var("APPVEYOR")
 run_by_rtd = get_bool_env_var("READTHEDOCS")
-run_by_ci = (
-    run_by_github_actions
-    or run_by_travis_ci
-    or run_by_appveyor
-    or run_by_rtd
-    or get_bool_env_var("CI")
-)
+run_by_ci = run_by_github_actions or run_by_rtd or get_bool_env_var("CI")
 
 # -- Path setup ------------------------------------------------------------------------
 
@@ -107,8 +99,8 @@ intersphinx_mapping = {
 
 # -- sphinx-gallery configuration ------------------------------------------------------
 
-plot_gallery = get_bool_env_var("PYSTICHE_PLOT_GALLERY", default=True) and not run_by_ci
-download_gallery = get_bool_env_var("PYSTICHE_DOWNLOAD_GALLERY") or run_by_ci
+plot_gallery = get_bool_env_var("PYSTICHE_PLOT_GALLERY", default=not run_by_ci)
+download_gallery = get_bool_env_var("PYSTICHE_DOWNLOAD_GALLERY", default=run_by_ci)
 
 if download_gallery:
     base = "https://download.pystiche.org/galleries/"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -209,6 +209,17 @@ import pystiche.ops.functional as F
 
 import warnings
 warnings.filterwarnings("ignore", category=FutureWarning)
+
+from unittest import mock
+
+patcher = mock.patch(
+    "pystiche.enc.models.utils.ModelMultiLayerEncoder.load_state_dict_from_url"
+)
+patcher.start()
+"""
+
+doctest_global_cleanup = """
+mock.patch.stopall()
 """
 
 # -- Options for HTML output -----------------------------------------------------------

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,4 +1,5 @@
 .. _usage_examples:
+
 ``pystiche`` usage examples
 ===========================
 

--- a/tox.ini
+++ b/tox.ini
@@ -80,6 +80,7 @@ deps =
   # Additional sphinx-gallery dependencies
   # https://sphinx-gallery.github.io/stable/index.html#install-via-pip
   matplotlib
+  memory_profiler
 
 
 [docs-common]

--- a/tox.ini
+++ b/tox.ini
@@ -124,7 +124,7 @@ force_cpu = True
 deps = {[docs-common]deps}
 changedir = {[docs-common]changedir}
 commands =
-  sphinx-build -b doctest source build
+  sphinx-build -b doctest -W --keep-going source build
 
 [testenv:publishable]
 whitelist_externals =


### PR DESCRIPTION
`tox -e tests-docs` now errors if warnings are detected. An exception to this are `FutureWarning`s since suppressing them would clatter the examples.