### PR TITLE
remove obsolete installation information

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -1,10 +1,6 @@
 Installation
 ============
 
-``pystiche`` is a proper Python package and can be installed with ``pip``. It is not
-yet listed on `PyPI <https://pypi.org/>`_, since it will be reviewed at
-`pyOpenSci <https://github.com/pmeier/pystiche/issues/93>`_.
-
 The latest **stable** version can be installed with
 
 .. code-block:: sh


### PR DESCRIPTION
Since `pystiche==0.6.2` the package is hosted on PyPI and thus this paragraph is obsolete.