### PR TITLE
use caching by identity rather than equality

### DIFF
--- a/pystiche/enc/multi_layer_encoder.py
+++ b/pystiche/enc/multi_layer_encoder.py
@@ -148,9 +148,9 @@ class MultiLayerEncoder(pystiche.Module):
         super().__init__(named_children=modules)
         self._layers: _Layers = _Layers(self._modules)
         self.registered_layers: Set[str] = set()
-        self._cache: DefaultDict[
-            pystiche.TensorKey, Dict[str, torch.Tensor]
-        ] = defaultdict(lambda: {})
+        self._cache: DefaultDict[torch.Tensor, Dict[str, torch.Tensor]] = defaultdict(
+            lambda: {}
+        )
 
     def __contains__(self, layer: str) -> bool:
         r"""Is the layer part of the multi-layer encoder?
@@ -208,7 +208,7 @@ class MultiLayerEncoder(pystiche.Module):
             self._verify(layer)
 
         if cache is None:
-            cache = self._cache[pystiche.TensorKey(input)]
+            cache = self._cache[input]
         if layer in cache:
             return cache[layer]
 


### PR DESCRIPTION
Currenty, we are caching the intermediate encodings in a `enc.MultiLayerEncoder` (MLE) by pseudo-equality

https://github.com/pmeier/pystiche/blob/ee50bce69cfa4bc56e8b889caeaa891f8cbed1fe/pystiche/enc/multi_layer_encoder.py#L211

This might be expensive, since a `pystiche.TensorKey` calculates some summary statistics. Additionally and more importantly, this might lead to unexpected results if the MLE is called with a clone of a previously cached input. The original functionality was added in #78 unfortunately without comment on why equality was important.

This PR replaces the caching by "equality" to identity. This should speed up the process significantly by reducing the overhead while also being more sound in theory.